### PR TITLE
2.16.6:

### DIFF
--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -892,3 +892,8 @@ releases:
       bugfixes:
       - cisco.meraki.organizations_login_security module will not update org api authentication - fixing for look at organizations_login_security.
     release_date: '2023-10-10'
+  2.16.6:
+    changes:
+      bugfixes:
+      - runtime updated requires_ansible from 2.9.10 to '>=2.14.0'.
+    release_date: '2023-10-17'

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: cisco
 name: meraki
-version: 2.16.5
+version: 2.16.6
 readme: README.md
 authors:
   - Francisco Muñoz <fmunoz@cloverhound.com>


### PR DESCRIPTION
    changes:
      bugfixes:
      - runtime updated requires_ansible from 2.9.10 to '>=2.14.0'.
    release_date: '2023-10-17'