### PR TITLE
2.16.8:

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Other versions of this collection have support for previous Cisco Meraki version
 
 | Cisco Meraki version | Ansible "cisco.meraki" version | Python "DashboardAPI" version |
 |--------------------------|------------------------------|-------------------------------|
-| 1.33.0                    | 2.16.3                      |1.33.0                         |
+| 1.33.0                    | 2.16.5                      |1.33.0                         |
 
 *Notes*:
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -902,3 +902,8 @@ releases:
       bugfixes:
       - Sanity fixes.
     release_date: '2023-10-17'
+  2.16.8:
+    changes:
+      bugfixes:
+      - Returning requires_ansible to 2.9.10
+    release_date: '2023-10-17'

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,10 +1,10 @@
 ---
 namespace: cisco
 name: meraki
-version: 2.16.7
+version: 2.16.8
 readme: README.md
 authors:
-  - Francisco Muñoz <fmunoz@cloverhound.com>
+  - Francisco Muñoz <fmunoz@cloverhound.com> 
   - Bryan Vargas <bvargas@cloverhound.com>
   - William Astorga <wastorga@cloverhound.com>
   - Jose Bogarin <jbogarin@cloverhound.com>

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,5 +1,5 @@
 ---
-requires_ansible: '>=2.14.0'
+requires_ansible: '>=2.9.10'
 
 plugin_routing:
     modules:


### PR DESCRIPTION
    changes:
      bugfixes:
      - Returning requires_ansible to 2.9.10
    release_date: '2023-10-17'