### PR TITLE
2.16.11:

### DIFF
--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -913,3 +913,28 @@ releases:
       - Returning requires_ansible to >=2.14.0
       - Bad naming `networkId` parameter in `networks_devices_remove` and `networks_devices_claim_vmx`
     release_date: '2023-10-26'
+  2.16.11:
+    changes:
+      bugfixes:
+      - Bad naming `networkId` parameter in `networks_appliance_traffic_shaping_custom_performance_classes`.
+      - Bad naming `networkId` parameter in `networks_appliance_warm_spare_swap`.
+      - Bad naming `networkId` parameter in `networks_bind`.
+      - Bad naming `networkId` parameter in `networks_clients_provision`.
+      - Bad naming `networkId` parameter in `networks_firmware_upgrades_rollbacks`.
+      - Bad naming `networkId` parameter in `networks_firmware_upgrades_staged_events_rollbacks`.
+      - Bad naming `networkId` parameter in `networks_mqtt_brokers`.
+      - Bad naming `networkId` parameter in `networks_pii_requests_delete`.
+      - Bad naming `networkId` parameter in `networks_sm_devices_checkin`.
+      - Bad naming `networkId` parameter in `networks_sm_devices_lock`.
+      - Bad naming `networkId` parameter in `networks_sm_devices_modify_tags`.
+      - Bad naming `networkId` parameter in `networks_sm_devices_move`.
+      - Bad naming `networkId` parameter in `networks_sm_devices_refresh_details`.
+      - Bad naming `networkId` parameter in `networks_sm_devices_unenroll`.
+      - Bad naming `networkId` parameter in `networks_sm_devices_wipe`.
+      - Bad naming `networkId` parameter in `networks_sm_user_access_devices_delete`.
+      - Bad naming `networkId` parameter in `networks_split`.
+      - Bad naming `networkId` parameter in `networks_switch_stacks_add`.
+      - Bad naming `networkId` parameter in `networks_switch_stacks_remove`.
+      - Bad naming `networkId` parameter in `networks_unbind`.
+      - Bad naming `networkId` parameter in `networks_sm_devices_fields`.
+    release_date: '2023-10-26'

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: cisco
 name: meraki
-version: 2.16.10
+version: 2.16.11
 readme: README.md
 authors:
   - Francisco Muñoz <fmunoz@cloverhound.com> 

--- a/plugins/action/networks_appliance_traffic_shaping_custom_performance_classes.py
+++ b/plugins/action/networks_appliance_traffic_shaping_custom_performance_classes.py
@@ -72,7 +72,7 @@ class ActionModule(ActionBase):
             maxLatency=params.get("maxLatency"),
             maxJitter=params.get("maxJitter"),
             maxLossPercentage=params.get("maxLossPercentage"),
-            network_id=params.get("networkId"),
+            networkId=params.get("networkId"),
         )
         return new_object
 

--- a/plugins/action/networks_appliance_warm_spare_swap.py
+++ b/plugins/action/networks_appliance_warm_spare_swap.py
@@ -64,7 +64,7 @@ class ActionModule(ActionBase):
 
     def get_object(self, params):
         new_object = dict(
-            network_id=params.get("networkId"),
+            networkId=params.get("networkId"),
         )
         return new_object
 

--- a/plugins/action/networks_bind.py
+++ b/plugins/action/networks_bind.py
@@ -68,7 +68,7 @@ class ActionModule(ActionBase):
         new_object = dict(
             configTemplateId=params.get("configTemplateId"),
             autoBind=params.get("autoBind"),
-            network_id=params.get("networkId"),
+            networkId=params.get("networkId"),
         )
         return new_object
 

--- a/plugins/action/networks_clients_provision.py
+++ b/plugins/action/networks_clients_provision.py
@@ -74,7 +74,7 @@ class ActionModule(ActionBase):
             groupPolicyId=params.get("groupPolicyId"),
             policiesBySecurityAppliance=params.get("policiesBySecurityAppliance"),
             policiesBySsid=params.get("policiesBySsid"),
-            network_id=params.get("networkId"),
+            networkId=params.get("networkId"),
         )
         return new_object
 

--- a/plugins/action/networks_firmware_upgrades_rollbacks.py
+++ b/plugins/action/networks_firmware_upgrades_rollbacks.py
@@ -72,7 +72,7 @@ class ActionModule(ActionBase):
             time=params.get("time"),
             reasons=params.get("reasons"),
             toVersion=params.get("toVersion"),
-            network_id=params.get("networkId"),
+            networkId=params.get("networkId"),
         )
         return new_object
 

--- a/plugins/action/networks_firmware_upgrades_staged_events_rollbacks.py
+++ b/plugins/action/networks_firmware_upgrades_staged_events_rollbacks.py
@@ -68,7 +68,7 @@ class ActionModule(ActionBase):
         new_object = dict(
             stages=params.get("stages"),
             reasons=params.get("reasons"),
-            network_id=params.get("networkId"),
+            networkId=params.get("networkId"),
         )
         return new_object
 

--- a/plugins/action/networks_mqtt_brokers.py
+++ b/plugins/action/networks_mqtt_brokers.py
@@ -74,7 +74,7 @@ class ActionModule(ActionBase):
             port=params.get("port"),
             security=params.get("security"),
             authentication=params.get("authentication"),
-            network_id=params.get("networkId"),
+            networkId=params.get("networkId"),
         )
         return new_object
 

--- a/plugins/action/networks_pii_requests_delete.py
+++ b/plugins/action/networks_pii_requests_delete.py
@@ -65,8 +65,8 @@ class ActionModule(ActionBase):
 
     def get_object(self, params):
         new_object = dict(
-            network_id=params.get("networkId"),
-            request_id=params.get("requestId"),
+            networkId=params.get("networkId"),
+            requestId=params.get("requestId"),
         )
         return new_object
 

--- a/plugins/action/networks_sm_devices_checkin.py
+++ b/plugins/action/networks_sm_devices_checkin.py
@@ -72,7 +72,7 @@ class ActionModule(ActionBase):
             ids=params.get("ids"),
             serials=params.get("serials"),
             scope=params.get("scope"),
-            network_id=params.get("networkId"),
+            networkId=params.get("networkId"),
         )
         return new_object
 

--- a/plugins/action/networks_sm_devices_fields.py
+++ b/plugins/action/networks_sm_devices_fields.py
@@ -72,7 +72,7 @@ class ActionModule(ActionBase):
             id=params.get("id"),
             serial=params.get("serial"),
             deviceFields=params.get("deviceFields"),
-            network_id=params.get("networkId"),
+            networkId=params.get("networkId"),
         )
         return new_object
 

--- a/plugins/action/networks_sm_devices_lock.py
+++ b/plugins/action/networks_sm_devices_lock.py
@@ -74,7 +74,7 @@ class ActionModule(ActionBase):
             serials=params.get("serials"),
             scope=params.get("scope"),
             pin=params.get("pin"),
-            network_id=params.get("networkId"),
+            networkId=params.get("networkId"),
         )
         return new_object
 

--- a/plugins/action/networks_sm_devices_modify_tags.py
+++ b/plugins/action/networks_sm_devices_modify_tags.py
@@ -76,7 +76,7 @@ class ActionModule(ActionBase):
             scope=params.get("scope"),
             tags=params.get("tags"),
             updateAction=params.get("updateAction"),
-            network_id=params.get("networkId"),
+            networkId=params.get("networkId"),
         )
         return new_object
 

--- a/plugins/action/networks_sm_devices_move.py
+++ b/plugins/action/networks_sm_devices_move.py
@@ -74,7 +74,7 @@ class ActionModule(ActionBase):
             serials=params.get("serials"),
             scope=params.get("scope"),
             newNetwork=params.get("newNetwork"),
-            network_id=params.get("networkId"),
+            networkId=params.get("networkId"),
         )
         return new_object
 

--- a/plugins/action/networks_sm_devices_refresh_details.py
+++ b/plugins/action/networks_sm_devices_refresh_details.py
@@ -65,8 +65,8 @@ class ActionModule(ActionBase):
 
     def get_object(self, params):
         new_object = dict(
-            network_id=params.get("networkId"),
-            device_id=params.get("deviceId"),
+            networkId=params.get("networkId"),
+            deviceId=params.get("deviceId"),
         )
         return new_object
 

--- a/plugins/action/networks_sm_devices_unenroll.py
+++ b/plugins/action/networks_sm_devices_unenroll.py
@@ -65,8 +65,8 @@ class ActionModule(ActionBase):
 
     def get_object(self, params):
         new_object = dict(
-            network_id=params.get("networkId"),
-            device_id=params.get("deviceId"),
+            networkId=params.get("networkId"),
+            deviceId=params.get("deviceId"),
         )
         return new_object
 

--- a/plugins/action/networks_sm_devices_wipe.py
+++ b/plugins/action/networks_sm_devices_wipe.py
@@ -72,7 +72,7 @@ class ActionModule(ActionBase):
             id=params.get("id"),
             serial=params.get("serial"),
             pin=params.get("pin"),
-            network_id=params.get("networkId"),
+            networkId=params.get("networkId"),
         )
         return new_object
 

--- a/plugins/action/networks_sm_user_access_devices_delete.py
+++ b/plugins/action/networks_sm_user_access_devices_delete.py
@@ -65,8 +65,8 @@ class ActionModule(ActionBase):
 
     def get_object(self, params):
         new_object = dict(
-            network_id=params.get("networkId"),
-            user_access_device_id=params.get("userAccessDeviceId"),
+            networkId=params.get("networkId"),
+            userAccessDeviceId=params.get("userAccessDeviceId"),
         )
         return new_object
 

--- a/plugins/action/networks_split.py
+++ b/plugins/action/networks_split.py
@@ -64,7 +64,7 @@ class ActionModule(ActionBase):
 
     def get_object(self, params):
         new_object = dict(
-            network_id=params.get("networkId"),
+            networkId=params.get("networkId"),
         )
         return new_object
 

--- a/plugins/action/networks_switch_stacks_add.py
+++ b/plugins/action/networks_switch_stacks_add.py
@@ -67,8 +67,8 @@ class ActionModule(ActionBase):
     def get_object(self, params):
         new_object = dict(
             serial=params.get("serial"),
-            network_id=params.get("networkId"),
-            switch_stack_id=params.get("switchStackId"),
+            networkId=params.get("networkId"),
+            switchStackId=params.get("switchStackId"),
         )
         return new_object
 

--- a/plugins/action/networks_switch_stacks_remove.py
+++ b/plugins/action/networks_switch_stacks_remove.py
@@ -67,8 +67,8 @@ class ActionModule(ActionBase):
     def get_object(self, params):
         new_object = dict(
             serial=params.get("serial"),
-            network_id=params.get("networkId"),
-            switch_stack_id=params.get("switchStackId"),
+            networkId=params.get("networkId"),
+            switchStackId=params.get("switchStackId"),
         )
         return new_object
 

--- a/plugins/action/networks_unbind.py
+++ b/plugins/action/networks_unbind.py
@@ -66,7 +66,7 @@ class ActionModule(ActionBase):
     def get_object(self, params):
         new_object = dict(
             retainConfigs=params.get("retainConfigs"),
-            network_id=params.get("networkId"),
+            networkId=params.get("networkId"),
         )
         return new_object
 


### PR DESCRIPTION
    changes:
      bugfixes:
      - Bad naming `networkId` parameter in `networks_appliance_traffic_shaping_custom_performance_classes`.
      - Bad naming `networkId` parameter in `networks_appliance_warm_spare_swap`.
      - Bad naming `networkId` parameter in `networks_bind`.
      - Bad naming `networkId` parameter in `networks_clients_provision`.
      - Bad naming `networkId` parameter in `networks_firmware_upgrades_rollbacks`.
      - Bad naming `networkId` parameter in `networks_firmware_upgrades_staged_events_rollbacks`.
      - Bad naming `networkId` parameter in `networks_mqtt_brokers`.
      - Bad naming `networkId` parameter in `networks_pii_requests_delete`.
      - Bad naming `networkId` parameter in `networks_sm_devices_checkin`.
      - Bad naming `networkId` parameter in `networks_sm_devices_lock`.
      - Bad naming `networkId` parameter in `networks_sm_devices_modify_tags`.
      - Bad naming `networkId` parameter in `networks_sm_devices_move`.
      - Bad naming `networkId` parameter in `networks_sm_devices_refresh_details`.
      - Bad naming `networkId` parameter in `networks_sm_devices_unenroll`.
      - Bad naming `networkId` parameter in `networks_sm_devices_wipe`.
      - Bad naming `networkId` parameter in `networks_sm_user_access_devices_delete`.
      - Bad naming `networkId` parameter in `networks_split`.
      - Bad naming `networkId` parameter in `networks_switch_stacks_add`.
      - Bad naming `networkId` parameter in `networks_switch_stacks_remove`.
      - Bad naming `networkId` parameter in `networks_unbind`.
      - Bad naming `networkId` parameter in `networks_sm_devices_fields`.
    release_date: '2023-10-26'