### PR TITLE
2.16.16:

### DIFF
--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -960,3 +960,25 @@ releases:
       - Adding `network_clients_info` and `network_client_info`.
       - Adding `platform_meraki.rst` to docs.
     release_date: '2023-11-14'
+  2.16.16:
+    changes:
+      bugfixes:
+        - Idempotency bugs fixed in devices_switch_ports.
+        - Adding `product_types` for update request on networks.
+        - networks_syslog_servers is now just an Update action to API.
+        - Parameter`organization_id` change to `organizationId` organizations_claim.
+        - Parameter`organization_id` change to `organizationId` organizations_clone.
+        - Parameter`organization_id` change to `organizationId` organizations_inventory_claim.
+        - Parameter`organization_id` change to `organizationId` organizations_inventory_onboarding_cloud_monitoring_export_events.
+        - Parameter`organization_id` change to `organizationId` organizations_inventory_onboarding_cloud_monitoring_prepare.
+        - Parameter`organization_id` change to `organizationId` organizations_inventory_release.
+        - Parameter`organization_id` change to `organizationId` organizations_licenses_assign_seats.
+        - Parameter`organization_id` change to `organizationId` organizations_licenses_move.
+        - Parameter`organization_id` change to `organizationId` organizations_licenses_move_seats.
+        - Parameter`organization_id` change to `organizationId` organizations_licenses_renew_seats.
+        - Parameter`organization_id` change to `organizationId` organizations_licensing_coterm_licenses_move.
+        - Parameter`organization_id` change to `organizationId` organizations_networks_combine.
+        - Parameter`organization_id` change to `organizationId` organizations_switch_devices_clone.
+        - Parameter`organization_id` change to `organizationId` organizations_users.
+        - Removing logs in meraki.py.
+    release_date: '2023-11-30'

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: cisco
 name: meraki
-version: 2.16.15
+version: 2.16.16
 readme: README.md
 authors:
   - Francisco Muñoz <fmunoz@cloverhound.com> 

--- a/playbooks/Get_AP_Serials.yaml
+++ b/playbooks/Get_AP_Serials.yaml
@@ -19,4 +19,3 @@
     - name: Show All Devices
       ansible.builtin.debug:
         msg: "{{ aps }}"
-

--- a/playbooks/networks.yml
+++ b/playbooks/networks.yml
@@ -1,35 +1,35 @@
 ---
-- hosts: localhost
-  gather_facts: false
-  tasks:
-    - name: Get all networks
-      cisco.meraki.networks_info:
-        # configTemplateId: string
-        # isBoundToConfigTemplate: True
-        # tags: []
-        # tagsFilterType: string
-        # perPage: 0
-        # startingAfter: string
-        # endingBefore: string
-        organizationId: "828099381482762270"
-      register: result
-    - name: Get all networks2
-      cisco.meraki.networks_clients_info:
-        # configTemplateId: string
-        # isBoundToConfigTemplate: True
-        # tags: []
-        # tagsFilterType: string
-        # perPage: 0
-        # startingAfter: string
-        # endingBefore: string
-        # organizationId: "828099381482762270"
-        networkId: "{{item.id}}"
-      loop: "{{result.meraki_response}}"
-      register: result2
+# - hosts: localhost
+#   gather_facts: false
+#   tasks:
+#     - name: Get all networks
+#       cisco.meraki.networks_info:
+#         # configTemplateId: string
+#         # isBoundToConfigTemplate: True
+#         # tags: []
+#         # tagsFilterType: string
+#         # perPage: 0
+#         # startingAfter: string
+#         # endingBefore: string
+#         organizationId: "828099381482762270"
+#       register: result
+#     - name: Get all networks2
+#       cisco.meraki.networks_clients_info:
+#         # configTemplateId: string
+#         # isBoundToConfigTemplate: True
+#         # tags: []
+#         # tagsFilterType: string
+#         # perPage: 0
+#         # startingAfter: string
+#         # endingBefore: string
+#         # organizationId: "828099381482762270"
+#         networkId: "{{item.id}}"
+#       loop: "{{result.meraki_response}}"
+#       register: result2
 
-    - name: Show result
-      ansible.builtin.debug:
-        msg: "{{ result2 }}"
+#     - name: Show result
+#       ansible.builtin.debug:
+#         msg: "{{ result2 }}"
 
 
     # - name: Create
@@ -48,3 +48,21 @@
     #     - tag1
     #     - tag3
     #     timeZone: America/Los_Angeles
+
+- hosts: localhost
+  vars:
+    org_id: 828099381482762270 
+  gather_facts: false
+  tasks:
+
+  - name: Createa a new network
+    cisco.meraki.networks:
+      meraki_suppress_logging: false
+      state: present
+      name: New network by Ansible
+      notes: Additional description of the network
+      organizationId: "{{ org_id }}"
+      productTypes:
+      - appliance
+      - switch
+      timeZone: America/Los_Angeles 

--- a/playbooks/test.yml
+++ b/playbooks/test.yml
@@ -7,6 +7,19 @@
   gather_facts: false
   tasks:
 
+    # - name: Get all networks _appliance _ports
+    #   cisco.meraki.networks_appliance_ports_info:
+    #     networkId: L_828099381482771185
+    #   register: result
+    - name: update port
+      cisco.meraki.devices_switch_ports:
+        meraki_suppress_logging: false
+        serial: QBSB-BNH2-KDXJ
+        portId: 3
+        vlan: 50
+        # type: access
+        state: present
+        poeEnabled: false 
     # - name: Update appliance Vlans
     #   cisco.meraki.networks_appliance_vlans:
     #     state: present
@@ -106,10 +119,10 @@
     #     networkId: "{{network_id}}"
 
 
-    - name: change name of device
-      cisco.meraki.devices:
-        name: new name 4
-        serial: QBSB-D5ZD-9CXT
-        # organizationId: "{{org_id}}"
-        state: present 
-        meraki_suppress_logging: false
+    # - name: change name of device
+    #   cisco.meraki.devices:
+    #     name: new name 4
+    #     serial: QBSB-D5ZD-9CXT
+    #     # organizationId: "{{org_id}}"
+    #     state: present 
+    #     meraki_suppress_logging: false

--- a/plugins/action/devices_switch_ports.py
+++ b/plugins/action/devices_switch_ports.py
@@ -20,7 +20,7 @@ from ansible.errors import AnsibleActionFail
 from ansible_collections.cisco.meraki.plugins.plugin_utils.meraki import (
     MERAKI,
     meraki_argument_spec,
-    meraki_compare_equality,
+    meraki_compare_equality2,
     get_dict_result,
 )
 from ansible_collections.cisco.meraki.plugins.plugin_utils.exceptions import (
@@ -196,6 +196,7 @@ class DevicesSwitchPorts(object):
 
     def get_object_by_name(self, name):
         result = None
+        name = self.new_object.get('portId') or self.new_object.get('port_id')
         # NOTE: Does not have a get by name method, using get all
         try:
             items = self.meraki.exec_meraki(
@@ -206,7 +207,7 @@ class DevicesSwitchPorts(object):
             if isinstance(items, dict):
                 if 'response' in items:
                     items = items.get('response')
-            result = get_dict_result(items, 'name', name)
+            result = get_dict_result(items, 'portId', name)
             if result is None:
                 result = items
         except Exception as e:
@@ -293,7 +294,7 @@ class DevicesSwitchPorts(object):
         ]
         # Method 1. Params present in request (Ansible) obj are the same as the current (ISE) params
         # If any does not have eq params, it requires update
-        return any(not meraki_compare_equality(current_obj.get(meraki_param),
+        return any(not meraki_compare_equality2(current_obj.get(meraki_param),
                                                requested_obj.get(ansible_param))
                    for (meraki_param, ansible_param) in obj_params)
 

--- a/plugins/action/devices_switch_ports.py
+++ b/plugins/action/devices_switch_ports.py
@@ -142,9 +142,11 @@ class DevicesSwitchPorts(object):
             new_object_params['allowedVlans'] = self.new_object.get('allowedVlans') or \
                 self.new_object.get('allowed_vlans')
         if self.new_object.get('isolationEnabled') is not None or self.new_object.get('isolation_enabled') is not None:
-            new_object_params['isolationEnabled'] = self.new_object.get('isolationEnabled')
+            new_object_params['isolationEnabled'] = self.new_object.get(
+                'isolationEnabled')
         if self.new_object.get('rstpEnabled') is not None or self.new_object.get('rstp_enabled') is not None:
-            new_object_params['rstpEnabled'] = self.new_object.get('rstpEnabled')
+            new_object_params['rstpEnabled'] = self.new_object.get(
+                'rstpEnabled')
         if self.new_object.get('stpGuard') is not None or self.new_object.get('stp_guard') is not None:
             new_object_params['stpGuard'] = self.new_object.get('stpGuard') or \
                 self.new_object.get('stp_guard')
@@ -173,14 +175,17 @@ class DevicesSwitchPorts(object):
             new_object_params['stickyMacAllowListLimit'] = self.new_object.get('stickyMacAllowListLimit') or \
                 self.new_object.get('sticky_mac_allow_list_limit')
         if self.new_object.get('stormControlEnabled') is not None or self.new_object.get('storm_control_enabled') is not None:
-            new_object_params['stormControlEnabled'] = self.new_object.get('stormControlEnabled')
+            new_object_params['stormControlEnabled'] = self.new_object.get(
+                'stormControlEnabled')
         if self.new_object.get('adaptivePolicyGroupId') is not None or self.new_object.get('adaptive_policy_group_id') is not None:
             new_object_params['adaptivePolicyGroupId'] = self.new_object.get('adaptivePolicyGroupId') or \
                 self.new_object.get('adaptive_policy_group_id')
         if self.new_object.get('peerSgtCapable') is not None or self.new_object.get('peer_sgt_capable') is not None:
-            new_object_params['peerSgtCapable'] = self.new_object.get('peerSgtCapable')
+            new_object_params['peerSgtCapable'] = self.new_object.get(
+                'peerSgtCapable')
         if self.new_object.get('flexibleStackingEnabled') is not None or self.new_object.get('flexible_stacking_enabled') is not None:
-            new_object_params['flexibleStackingEnabled'] = self.new_object.get('flexibleStackingEnabled')
+            new_object_params['flexibleStackingEnabled'] = self.new_object.get(
+                'flexibleStackingEnabled')
         if self.new_object.get('daiTrusted') is not None or self.new_object.get('dai_trusted') is not None:
             new_object_params['daiTrusted'] = self.new_object.get('daiTrusted')
         if self.new_object.get('profile') is not None or self.new_object.get('profile') is not None:
@@ -295,7 +300,7 @@ class DevicesSwitchPorts(object):
         # Method 1. Params present in request (Ansible) obj are the same as the current (ISE) params
         # If any does not have eq params, it requires update
         return any(not meraki_compare_equality2(current_obj.get(meraki_param),
-                                               requested_obj.get(ansible_param))
+                                                requested_obj.get(ansible_param))
                    for (meraki_param, ansible_param) in obj_params)
 
     def update(self):

--- a/plugins/action/networks.py
+++ b/plugins/action/networks.py
@@ -142,6 +142,9 @@ class Networks(object):
         if self.new_object.get('timeZone') is not None or self.new_object.get('time_zone') is not None:
             new_object_params['timeZone'] = self.new_object.get('timeZone') or \
                 self.new_object.get('time_zone')
+        if self.new_object.get('productTypes') is not None or self.new_object.get('product_types') is not None:
+            new_object_params['productTypes'] = self.new_object.get('productTypes') or \
+                self.new_object.get('product_types')
         if self.new_object.get('tags') is not None or self.new_object.get('tags') is not None:
             new_object_params['tags'] = self.new_object.get('tags') or \
                 self.new_object.get('tags')

--- a/plugins/action/networks_syslog_servers.py
+++ b/plugins/action/networks_syslog_servers.py
@@ -2,8 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2021, Cisco Systems
-# GNU General Public License v3.0+ (see LICENSE or
-# https://www.gnu.org/licenses/gpl-3.0.txt)
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
@@ -20,126 +19,20 @@ from ansible.errors import AnsibleActionFail
 from ansible_collections.cisco.meraki.plugins.plugin_utils.meraki import (
     MERAKI,
     meraki_argument_spec,
-    meraki_compare_equality,
-    get_dict_result,
-)
-from ansible_collections.cisco.meraki.plugins.plugin_utils.exceptions import (
-    InconsistentParameters,
 )
 
-# Get common arguments specification
+# Get common arguements specification
 argument_spec = meraki_argument_spec()
 # Add arguments specific for this module
 argument_spec.update(dict(
-    state=dict(type="str", default="present", choices=["present"]),
     servers=dict(type="list"),
     networkId=dict(type="str"),
 ))
 
-required_if = [
-    ("state", "present", ["networkId"], True),
-]
+required_if = []
 required_one_of = []
 mutually_exclusive = []
 required_together = []
-
-
-class NetworksSyslogServers(object):
-    def __init__(self, params, meraki):
-        self.meraki = meraki
-        self.new_object = dict(
-            servers=params.get("servers"),
-            network_id=params.get("networkId"),
-        )
-
-    def get_all_params(self, name=None, id=None):
-        new_object_params = {}
-        if self.new_object.get('networkId') is not None or self.new_object.get('network_id') is not None:
-            new_object_params['networkId'] = self.new_object.get('networkId') or \
-                self.new_object.get('network_id')
-        return new_object_params
-
-    def update_all_params(self):
-        new_object_params = {}
-        if self.new_object.get('servers') is not None or self.new_object.get('servers') is not None:
-            new_object_params['servers'] = self.new_object.get('servers') or \
-                self.new_object.get('servers')
-        if self.new_object.get('networkId') is not None or self.new_object.get('network_id') is not None:
-            new_object_params['networkId'] = self.new_object.get('networkId') or \
-                self.new_object.get('network_id')
-        return new_object_params
-
-    def get_object_by_name(self, name):
-        result = None
-        # NOTE: Does not have a get by name method, using get all
-        try:
-            items = self.meraki.exec_meraki(
-                family="networks",
-                function="getNetworkSyslogServers",
-                params=self.get_all_params(name=name),
-            )
-            if isinstance(items, dict):
-                if 'servers' in items:
-                    items = items.get('servers')
-            result = get_dict_result(items, 'name', name)
-            if result is None:
-                result = items
-        except Exception as e:
-            print("Error: ", e)
-            result = None
-        return result
-
-    def get_object_by_id(self, id):
-        result = None
-        # NOTE: Does not have a get by id method or it is in another action
-        return result
-
-    def exists(self):
-        prev_obj = None
-        id_exists = False
-        name_exists = False
-        o_id = self.new_object.get("networkId") or self.new_object.get("network_id")
-        name = self.new_object.get("name")
-        if o_id:
-            prev_obj = self.get_object_by_name(o_id)
-            id_exists = prev_obj is not None and isinstance(prev_obj, dict)
-        if not id_exists and name:
-            prev_obj = self.get_object_by_name(name)
-            name_exists = prev_obj is not None and isinstance(prev_obj, dict)
-        if name_exists:
-            _id = prev_obj.get("id")
-            if id_exists and name_exists and o_id != _id:
-                raise InconsistentParameters(
-                    "The 'id' and 'name' params don't refer to the same object")
-            if _id:
-                self.new_object.update(dict(id=_id))
-        it_exists = prev_obj is not None and isinstance(prev_obj, dict)
-        return (it_exists, prev_obj)
-
-    def requires_update(self, current_obj):
-        requested_obj = self.new_object
-
-        obj_params = [
-            ("servers", "servers"),
-            ("networkId", "networkId"),
-        ]
-        # Method 1. Params present in request (Ansible) obj are the same as the current (ISE) params
-        # If any does not have eq params, it requires update
-        return any(not meraki_compare_equality(current_obj.get(meraki_param),
-                                               requested_obj.get(ansible_param))
-                   for (meraki_param, ansible_param) in obj_params)
-
-    def update(self):
-        id = self.new_object.get("id")
-        name = self.new_object.get("name")
-        result = None
-        result = self.meraki.exec_meraki(
-            family="networks",
-            function="updateNetworkSyslogServers",
-            params=self.update_all_params(),
-            op_modifies=True,
-        )
-        return result
 
 
 class ActionModule(ActionBase):
@@ -170,31 +63,27 @@ class ActionModule(ActionBase):
         if not valid:
             raise AnsibleActionFail(errors)
 
+    def get_object(self, params):
+        new_object = dict(
+            servers=params.get("servers"),
+            networkId=params.get("networkId"),
+        )
+        return new_object
+
     def run(self, tmp=None, task_vars=None):
         self._task.diff = False
         self._result = super(ActionModule, self).run(tmp, task_vars)
         self._result["changed"] = False
         self._check_argspec()
 
-        meraki = MERAKI(self._task.args)
-        obj = NetworksSyslogServers(self._task.args, meraki)
+        meraki = MERAKI(params=self._task.args)
 
-        state = self._task.args.get("state")
-
-        response = None
-        if state == "present":
-            (obj_exists, prev_obj) = obj.exists()
-            if obj_exists:
-                if obj.requires_update(prev_obj):
-                    response = obj.update()
-                    meraki.object_updated()
-                else:
-                    response = prev_obj
-                    meraki.object_already_present()
-            else:
-                meraki.fail_json(
-                    "Object does not exists, plugin only has update")
-
+        response = meraki.exec_meraki(
+            family="networks",
+            function='updateNetworkSyslogServers',
+            op_modifies=True,
+            params=self.get_object(self._task.args),
+        )
         self._result.update(dict(meraki_response=response))
         self._result.update(meraki.exit_json())
         return self._result

--- a/plugins/action/organizations_claim.py
+++ b/plugins/action/organizations_claim.py
@@ -70,7 +70,7 @@ class ActionModule(ActionBase):
             orders=params.get("orders"),
             serials=params.get("serials"),
             licenses=params.get("licenses"),
-            organization_id=params.get("organizationId"),
+            organizationId=params.get("organizationId"),
         )
         return new_object
 

--- a/plugins/action/organizations_clone.py
+++ b/plugins/action/organizations_clone.py
@@ -66,7 +66,7 @@ class ActionModule(ActionBase):
     def get_object(self, params):
         new_object = dict(
             name=params.get("name"),
-            organization_id=params.get("organizationId"),
+            organizationId=params.get("organizationId"),
         )
         return new_object
 

--- a/plugins/action/organizations_inventory_claim.py
+++ b/plugins/action/organizations_inventory_claim.py
@@ -70,7 +70,7 @@ class ActionModule(ActionBase):
             orders=params.get("orders"),
             serials=params.get("serials"),
             licenses=params.get("licenses"),
-            organization_id=params.get("organizationId"),
+            organizationId=params.get("organizationId"),
         )
         return new_object
 

--- a/plugins/action/organizations_inventory_onboarding_cloud_monitoring_export_events.py
+++ b/plugins/action/organizations_inventory_onboarding_cloud_monitoring_export_events.py
@@ -72,7 +72,7 @@ class ActionModule(ActionBase):
             timestamp=params.get("timestamp"),
             targetOS=params.get("targetOS"),
             request=params.get("request"),
-            organization_id=params.get("organizationId"),
+            organizationId=params.get("organizationId"),
         )
         return new_object
 

--- a/plugins/action/organizations_inventory_onboarding_cloud_monitoring_prepare.py
+++ b/plugins/action/organizations_inventory_onboarding_cloud_monitoring_prepare.py
@@ -66,7 +66,7 @@ class ActionModule(ActionBase):
     def get_object(self, params):
         new_object = dict(
             devices=params.get("devices"),
-            organization_id=params.get("organizationId"),
+            organizationId=params.get("organizationId"),
         )
         return new_object
 

--- a/plugins/action/organizations_inventory_release.py
+++ b/plugins/action/organizations_inventory_release.py
@@ -66,7 +66,7 @@ class ActionModule(ActionBase):
     def get_object(self, params):
         new_object = dict(
             serials=params.get("serials"),
-            organization_id=params.get("organizationId"),
+            organizationId=params.get("organizationId"),
         )
         return new_object
 

--- a/plugins/action/organizations_licenses_assign_seats.py
+++ b/plugins/action/organizations_licenses_assign_seats.py
@@ -70,7 +70,7 @@ class ActionModule(ActionBase):
             licenseId=params.get("licenseId"),
             networkId=params.get("networkId"),
             seatCount=params.get("seatCount"),
-            organization_id=params.get("organizationId"),
+            organizationId=params.get("organizationId"),
         )
         return new_object
 

--- a/plugins/action/organizations_licenses_move.py
+++ b/plugins/action/organizations_licenses_move.py
@@ -68,7 +68,7 @@ class ActionModule(ActionBase):
         new_object = dict(
             destOrganizationId=params.get("destOrganizationId"),
             licenseIds=params.get("licenseIds"),
-            organization_id=params.get("organizationId"),
+            organizationId=params.get("organizationId"),
         )
         return new_object
 

--- a/plugins/action/organizations_licenses_move_seats.py
+++ b/plugins/action/organizations_licenses_move_seats.py
@@ -70,7 +70,7 @@ class ActionModule(ActionBase):
             destOrganizationId=params.get("destOrganizationId"),
             licenseId=params.get("licenseId"),
             seatCount=params.get("seatCount"),
-            organization_id=params.get("organizationId"),
+            organizationId=params.get("organizationId"),
         )
         return new_object
 

--- a/plugins/action/organizations_licenses_renew_seats.py
+++ b/plugins/action/organizations_licenses_renew_seats.py
@@ -68,7 +68,7 @@ class ActionModule(ActionBase):
         new_object = dict(
             licenseIdToRenew=params.get("licenseIdToRenew"),
             unusedLicenseId=params.get("unusedLicenseId"),
-            organization_id=params.get("organizationId"),
+            organizationId=params.get("organizationId"),
         )
         return new_object
 

--- a/plugins/action/organizations_licensing_coterm_licenses_move.py
+++ b/plugins/action/organizations_licensing_coterm_licenses_move.py
@@ -68,7 +68,7 @@ class ActionModule(ActionBase):
         new_object = dict(
             destination=params.get("destination"),
             licenses=params.get("licenses"),
-            organization_id=params.get("organizationId"),
+            organizationId=params.get("organizationId"),
         )
         return new_object
 

--- a/plugins/action/organizations_networks_combine.py
+++ b/plugins/action/organizations_networks_combine.py
@@ -70,7 +70,7 @@ class ActionModule(ActionBase):
             name=params.get("name"),
             networkIds=params.get("networkIds"),
             enrollmentString=params.get("enrollmentString"),
-            organization_id=params.get("organizationId"),
+            organizationId=params.get("organizationId"),
         )
         return new_object
 

--- a/plugins/action/organizations_switch_devices_clone.py
+++ b/plugins/action/organizations_switch_devices_clone.py
@@ -68,7 +68,7 @@ class ActionModule(ActionBase):
         new_object = dict(
             sourceSerial=params.get("sourceSerial"),
             targetSerials=params.get("targetSerials"),
-            organization_id=params.get("organizationId"),
+            organizationId=params.get("organizationId"),
         )
         return new_object
 

--- a/plugins/action/organizations_users.py
+++ b/plugins/action/organizations_users.py
@@ -65,7 +65,7 @@ class ActionModule(ActionBase):
 
     def get_object(self, params):
         new_object = dict(
-            organization_id=params.get("organizationId"),
+            organizationId=params.get("organizationId"),
             user_id=params.get("userId"),
         )
         return new_object

--- a/plugins/plugin_utils/meraki.py
+++ b/plugins/plugin_utils/meraki.py
@@ -113,7 +113,7 @@ def fn_comp_key(k, dict1, dict2):
 
 
 def meraki_compare_equality(current_value, requested_value):
-    print("meraki_compare_equality", current_value, requested_value)
+    # print("meraki_compare_equality", current_value, requested_value)
     if requested_value is None:
         return True
     if current_value is None:


### PR DESCRIPTION
    changes:
      bugfixes:
        - Idempotency bugs fixed in devices_switch_ports.
        - Adding `product_types` for update request on networks. - networks_syslog_servers is now just an Update action to API. - Parameter`organization_id` change to `organizationId` organizations_claim. - Parameter`organization_id` change to `organizationId` organizations_clone. - Parameter`organization_id` change to `organizationId` organizations_inventory_claim. - Parameter`organization_id` change to `organizationId` organizations_inventory_onboarding_cloud_monitoring_export_events. - Parameter`organization_id` change to `organizationId` organizations_inventory_onboarding_cloud_monitoring_prepare. - Parameter`organization_id` change to `organizationId` organizations_inventory_release. - Parameter`organization_id` change to `organizationId` organizations_licenses_assign_seats. - Parameter`organization_id` change to `organizationId` organizations_licenses_move. - Parameter`organization_id` change to `organizationId` organizations_licenses_move_seats. - Parameter`organization_id` change to `organizationId` organizations_licenses_renew_seats. - Parameter`organization_id` change to `organizationId` organizations_licensing_coterm_licenses_move. - Parameter`organization_id` change to `organizationId` organizations_networks_combine. - Parameter`organization_id` change to `organizationId` organizations_switch_devices_clone. - Parameter`organization_id` change to `organizationId` organizations_users. - Removing logs in meraki.py. release_date: '2023-11-30'