### PR TITLE
2.18.1:

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Other versions of this collection have support for previous Cisco Meraki version
 | Cisco Meraki version | Ansible "cisco.meraki" version | Python "DashboardAPI" version |
 |--------------------------|------------------------------|-------------------------------|
 | 1.33.0                    | 2.17.0                      |1.33.0                         |
-| 1.44.1                    | 2.18.0                      |1.44.1                         |
+| 1.44.1                    | 2.18.1                      |1.44.1                         |
 
 *Notes*:
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -1064,3 +1064,10 @@ releases:
         - organizations_wireless_devices_packet_loss_by_client_info - new plugin.
         - organizations_wireless_devices_packet_loss_by_device_info - new plugin.
         - organizations_wireless_devices_packet_loss_by_network_info - new plugin.
+  2.18.1:
+    changes:
+      minor_changes:
+        - The `id` parameter is now required for `networks_appliance_vlans` module.
+        - The `id` parameter is change type to an `integer` in `networks_appliance_vlans` module.
+        - Fixing problem of naming in `organizations_appliance_vpn_third_party_vpnpeers_info`.
+        - Removing `state` from allowed parameters for `networks_syslog_servers` module.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: cisco
 name: meraki
-version: 2.18.0
+version: 2.18.1
 readme: README.md
 authors:
   - Francisco Muñoz <fmunoz@cloverhound.com> 

--- a/playbooks/test.yml
+++ b/playbooks/test.yml
@@ -127,9 +127,97 @@
     #     state: present 
     #     meraki_suppress_logging: false
 
-    - name: onboard order
-      cisco.meraki.organizations_inventory_claim:
-        # meraki_api_key: "{{ meraki_api }}"
-        # meraki_simulate: "{{ testpolicy }}"
-        organizationId: "{{ org_id }}"
-        orders: "1"
+    # - name: onboard order
+    #   cisco.meraki.organizations_inventory_claim:
+    #     # meraki_api_key: "{{ meraki_api }}"
+    #     # meraki_simulate: "{{ testpolicy }}"
+    #     organizationId: "{{ org_id }}"
+    #     orders: "1"
+    
+
+    # - name: Enable Vlans on the MX
+    #   cisco.meraki.networks_appliance_vlans_settings:
+    #     state: present
+    #     networkId: "{{network_id}}"
+    #     vlansEnabled: true
+
+    # - name: Create appliance Vlan 100
+    #   cisco.meraki.networks_appliance_vlans:
+    #     state: present
+    #     applianceIp: 192.168.1.2
+    #     cidr: 192.168.1.0/24
+    #     id: '100'
+    #     name: My VLAN
+    #     networkId: "{{network_id}}"
+    #     subnet: 192.168.1.0/24
+
+    # - name: Create appliance Vlan 200
+    #   cisco.meraki.networks_appliance_vlans:
+    #     state: present
+    #     applianceIp: 192.168.2.2
+    #     cidr: 192.168.2.0/24
+    #     id: '200'
+    #     name: My VLAN
+    #     networkId: "{{network_id}}"
+    #     subnet: 192.168.2.0/24
+
+    # - name: Create appliance Vlan 300
+    #   cisco.meraki.networks_appliance_vlans:
+    #     state: present
+    #     applianceIp: 192.168.3.2
+    #     cidr: 192.168.3.0/24
+    #     id: '300'
+    #     name: My VLAN
+    #     networkId: "{{network_id}}"
+    #     subnet: 192.168.3.0/24 
+
+
+    # - name: Enable Vlans on the MX
+    #   cisco.meraki.networks_appliance_vlans_settings:
+    #     state: present
+    #     networkId: "{{network_id}}"
+    #     vlansEnabled: true
+
+    # - name: Create appliance Vlan 100
+    #   cisco.meraki.networks_appliance_vlans:
+    #     state: present
+    #     meraki_suppress_logging: false
+    #     applianceIp: 10.1.0.2
+    #     cidr: 10.1.0.0/17
+    #     id: '100'
+    #     name: My VLAN
+    #     networkId: "{{network_id}}"
+    #     subnet: 10.1.0.0/17
+
+    # - name: Create appliance Vlan 200
+    #   cisco.meraki.networks_appliance_vlans:
+    #     state: present
+    #     meraki_suppress_logging: false
+    #     applianceIp: 172.200.0.2
+    #     cidr: 172.200.0.0/20
+    #     id: '200'
+    #     name: My VLAN
+    #     networkId: "{{network_id}}"
+    #     subnet: 172.200.0.0/20
+
+    # - name: Create appliance Vlan 300
+    #   cisco.meraki.networks_appliance_vlans:
+    #     state: present
+    #     meraki_suppress_logging: false
+    #     applianceIp: 172.16.0.2
+    #     cidr: 172.16.0.0/24
+    #     id: 300
+    #     name: My VLAN 2
+    #     networkId: "{{network_id}}"
+    #     subnet: 172.16.0.0/24
+
+  
+  # - name: Get all organizations _appliance _vpn _thirdpartyvpnpeers
+  #   cisco.meraki.organizations_appliance_vpn_third_party_vpnpeers_info:
+  #     meraki_suppress_logging: false
+  #     organizationId: "828099381482762270"
+  #   register: result
+
+  # - name: Show result
+  #   ansible.builtin.debug:
+  #     msg: "{{ result }}" 

--- a/plugins/action/networks_appliance_vlans.py
+++ b/plugins/action/networks_appliance_vlans.py
@@ -108,7 +108,7 @@ class NetworksApplianceVlans(object):
             new_object_params['networkId'] = self.new_object.get('networkId') or \
                 self.new_object.get('network_id')
         if self.new_object.get('vlanId') is not None or self.new_object.get('vlan_id') is not None or \
-        self.new_object.get('id') is not None:
+                self.new_object.get('id') is not None:
             new_object_params['vlanId'] = self.new_object.get('id') or \
                 self.new_object.get('id')
         return new_object_params
@@ -156,7 +156,7 @@ class NetworksApplianceVlans(object):
             new_object_params['networkId'] = self.new_object.get('networkId') or \
                 self.new_object.get('network_id')
         if self.new_object.get('vlanId') is not None or self.new_object.get('vlan_id') is not None or \
-        self.new_object.get('id') is not None:
+                self.new_object.get('id') is not None:
             new_object_params['vlanId'] = self.new_object.get('id') or \
                 self.new_object.get('id')
         return new_object_params
@@ -176,7 +176,8 @@ class NetworksApplianceVlans(object):
             new_object_params['dhcpBootNextServer'] = self.new_object.get('dhcpBootNextServer') or \
                 self.new_object.get('dhcp_boot_next_server')
         if self.new_object.get('dhcpBootOptionsEnabled') is not None or self.new_object.get('dhcp_boot_options_enabled') is not None:
-            new_object_params['dhcpBootOptionsEnabled'] = self.new_object.get('dhcpBootOptionsEnabled')
+            new_object_params['dhcpBootOptionsEnabled'] = self.new_object.get(
+                'dhcpBootOptionsEnabled')
         if self.new_object.get('dhcpHandling') is not None or self.new_object.get('dhcp_handling') is not None:
             new_object_params['dhcpHandling'] = self.new_object.get('dhcpHandling') or \
                 self.new_object.get('dhcp_handling')
@@ -226,7 +227,7 @@ class NetworksApplianceVlans(object):
             new_object_params['networkId'] = self.new_object.get('networkId') or \
                 self.new_object.get('network_id')
         if self.new_object.get('vlanId') is not None or self.new_object.get('vlan_id') is not None or \
-            self.new_object.get('id') is not None:
+                self.new_object.get('id') is not None:
             new_object_params['vlanId'] = self.new_object.get('id') or \
                 self.new_object.get('id')
         return new_object_params

--- a/plugins/action/networks_appliance_vlans.py
+++ b/plugins/action/networks_appliance_vlans.py
@@ -35,7 +35,7 @@ argument_spec.update(dict(
     applianceIp=dict(type="str"),
     cidr=dict(type="str"),
     groupPolicyId=dict(type="str"),
-    id=dict(type="str"),
+    id=dict(type="int"),
     ipv6=dict(type="dict"),
     mandatoryDhcp=dict(type="dict"),
     mask=dict(type="int"),
@@ -43,7 +43,7 @@ argument_spec.update(dict(
     subnet=dict(type="str"),
     templateVlanType=dict(type="str"),
     networkId=dict(type="str"),
-    vlanId=dict(type="str"),
+    # vlanId=dict(type="str"),
     dhcpBootFilename=dict(type="str"),
     dhcpBootNextServer=dict(type="str"),
     dhcpBootOptionsEnabled=dict(type="bool"),
@@ -58,8 +58,8 @@ argument_spec.update(dict(
 ))
 
 required_if = [
-    ("state", "present", ["name", "networkId", "vlanId"], True),
-    ("state", "absent", ["name", "networkId", "vlanId"], True),
+    ("state", "present", ["name", "networkId", "id"], True),
+    ("state", "absent", ["name", "networkId", "id"], True),
 ]
 required_one_of = []
 mutually_exclusive = []
@@ -107,9 +107,10 @@ class NetworksApplianceVlans(object):
         if self.new_object.get('networkId') is not None or self.new_object.get('network_id') is not None:
             new_object_params['networkId'] = self.new_object.get('networkId') or \
                 self.new_object.get('network_id')
-        if self.new_object.get('vlanId') is not None or self.new_object.get('vlan_id') is not None:
-            new_object_params['vlanId'] = self.new_object.get('vlanId') or \
-                self.new_object.get('vlan_id')
+        if self.new_object.get('vlanId') is not None or self.new_object.get('vlan_id') is not None or \
+        self.new_object.get('id') is not None:
+            new_object_params['vlanId'] = self.new_object.get('id') or \
+                self.new_object.get('id')
         return new_object_params
 
     def create_params(self):
@@ -154,9 +155,10 @@ class NetworksApplianceVlans(object):
         if self.new_object.get('networkId') is not None or self.new_object.get('network_id') is not None:
             new_object_params['networkId'] = self.new_object.get('networkId') or \
                 self.new_object.get('network_id')
-        if self.new_object.get('vlanId') is not None or self.new_object.get('vlan_id') is not None:
-            new_object_params['vlanId'] = self.new_object.get('vlanId') or \
-                self.new_object.get('vlan_id')
+        if self.new_object.get('vlanId') is not None or self.new_object.get('vlan_id') is not None or \
+        self.new_object.get('id') is not None:
+            new_object_params['vlanId'] = self.new_object.get('id') or \
+                self.new_object.get('id')
         return new_object_params
 
     def update_by_id_params(self):
@@ -223,9 +225,10 @@ class NetworksApplianceVlans(object):
         if self.new_object.get('networkId') is not None or self.new_object.get('network_id') is not None:
             new_object_params['networkId'] = self.new_object.get('networkId') or \
                 self.new_object.get('network_id')
-        if self.new_object.get('vlanId') is not None or self.new_object.get('vlan_id') is not None:
-            new_object_params['vlanId'] = self.new_object.get('vlanId') or \
-                self.new_object.get('vlan_id')
+        if self.new_object.get('vlanId') is not None or self.new_object.get('vlan_id') is not None or \
+            self.new_object.get('id') is not None:
+            new_object_params['vlanId'] = self.new_object.get('id') or \
+                self.new_object.get('id')
         return new_object_params
 
     def get_object_by_name(self, name):
@@ -272,7 +275,7 @@ class NetworksApplianceVlans(object):
         o_id = self.new_object.get("id")
         o_id = o_id or self.new_object.get(
             "vlan_id") or self.new_object.get("vlanId")
-        name = self.new_object.get("name")
+        name = None
         if o_id:
             prev_obj = self.get_object_by_id(o_id)
             id_exists = prev_obj is not None and isinstance(prev_obj, dict)
@@ -298,7 +301,6 @@ class NetworksApplianceVlans(object):
 
         obj_params = [
             ("applianceIp", "applianceIp"),
-            ("cidr", "cidr"),
             ("groupPolicyId", "groupPolicyId"),
             ("id", "id"),
             ("ipv6", "ipv6"),
@@ -308,7 +310,6 @@ class NetworksApplianceVlans(object):
             ("subnet", "subnet"),
             ("templateVlanType", "templateVlanType"),
             ("networkId", "networkId"),
-            ("vlanId", "vlanId"),
             ("dhcpBootFilename", "dhcpBootFilename"),
             ("dhcpBootNextServer", "dhcpBootNextServer"),
             ("dhcpBootOptionsEnabled", "dhcpBootOptionsEnabled"),

--- a/plugins/action/organizations_appliance_vpn_third_party_vpnpeers_info.py
+++ b/plugins/action/organizations_appliance_vpn_third_party_vpnpeers_info.py
@@ -82,7 +82,7 @@ class ActionModule(ActionBase):
 
         response = meraki.exec_meraki(
             family="appliance",
-            function='getOrganizationApplianceVpnThirdPartyVpnpeers',
+            function='getOrganizationApplianceVpnThirdPartyVPNPeers',
             params=self.get_all(self._task.args),
         )
         self._result.update(dict(meraki_response=response))

--- a/plugins/modules/networks_syslog_servers.py
+++ b/plugins/modules/networks_syslog_servers.py
@@ -74,7 +74,6 @@ EXAMPLES = r"""
     meraki_be_geo_id: "{{meraki_be_geo_id}}"
     meraki_use_iterator_for_get_pages: "{{meraki_use_iterator_for_get_pages}}"
     meraki_inherit_logging_config: "{{meraki_inherit_logging_config}}"
-    state: present
     networkId: string
     servers:
     - host: 1.2.3.4

--- a/tests/sanity/ignore-2.18.txt
+++ b/tests/sanity/ignore-2.18.txt
@@ -1,0 +1,1 @@
+plugins/modules/meraki_mx_intrusion_prevention.py validate-modules:invalid-argument-name


### PR DESCRIPTION
    changes:
      minor_changes:
        - The `id` parameter is now required for `networks_appliance_vlans` module.
        - The `id` parameter is change type to an `integer` in `networks_appliance_vlans` module. - Fixing problem of naming in `organizations_appliance_vpn_third_party_vpnpeers_info`. - Removing `state` from allowed parameters for `networks_syslog_servers` module.