### PR TITLE
Update runtime.yml

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,177 +1,665 @@
 ---
-requires_ansible: '>=2.14.0'
+requires_ansible: ">=2.14.0"
+action_groups:
+  meraki:
+    - organizations_info
+    - administered_identities_me_info
+    - administered_licensing_subscription_entitlements_info
+    - administered_licensing_subscription_subscriptions_bind
+    - administered_licensing_subscription_subscriptions_claim
+    - administered_licensing_subscription_subscriptions_claim_key_validate
+    - administered_licensing_subscription_subscriptions_compliance_statuses_info
+    - administered_licensing_subscription_subscriptions_info
+    - devices
+    - devices_appliance_performance_info
+    - devices_appliance_radio_settings
+    - devices_appliance_radio_settings_info
+    - devices_appliance_uplinks_settings
+    - devices_appliance_uplinks_settings_info
+    - devices_appliance_vmx_authentication_token
+    - devices_blink_leds
+    - devices_camera_analytics_live_info
+    - devices_camera_custom_analytics
+    - devices_camera_custom_analytics_info
+    - devices_camera_generate_snapshot
+    - devices_camera_quality_and_retention
+    - devices_camera_quality_and_retention_info
+    - devices_camera_sense
+    - devices_camera_sense_info
+    - devices_camera_video_link_info
+    - devices_camera_video_settings
+    - devices_camera_video_settings_info
+    - devices_camera_wireless_profiles
+    - devices_camera_wireless_profiles_info
+    - devices_cellular_gateway_lan
+    - devices_cellular_gateway_lan_info
+    - devices_cellular_gateway_port_forwarding_rules
+    - devices_cellular_gateway_port_forwarding_rules_info
+    - devices_cellular_sims
+    - devices_cellular_sims_info
+    - devices_info
+    - devices_live_tools_arp_table
+    - devices_live_tools_arp_table_info
+    - devices_live_tools_cable_test
+    - devices_live_tools_cable_test_info
+    - devices_live_tools_ping
+    - devices_live_tools_ping_device
+    - devices_live_tools_ping_device_info
+    - devices_live_tools_ping_info
+    - devices_live_tools_throughput_test
+    - devices_live_tools_throughput_test_info
+    - devices_live_tools_wake_on_lan
+    - devices_live_tools_wake_on_lan_info
+    - devices_lldp_cdp_info
+    - devices_management_interface
+    - devices_management_interface_info
+    - devices_sensor_relationships
+    - devices_sensor_relationships_info
+    - devices_switch_ports
+    - devices_switch_ports_cycle
+    - devices_switch_ports_info
+    - devices_switch_ports_statuses_info
+    - devices_switch_routing_interfaces
+    - devices_switch_routing_interfaces_dhcp
+    - devices_switch_routing_interfaces_dhcp_info
+    - devices_switch_routing_interfaces_info
+    - devices_switch_routing_static_routes
+    - devices_switch_routing_static_routes_info
+    - devices_switch_warm_spare
+    - devices_switch_warm_spare_info
+    - devices_wireless_alternate_management_interface_ipv6
+    - devices_wireless_bluetooth_settings
+    - devices_wireless_bluetooth_settings_info
+    - devices_wireless_connection_stats_info
+    - devices_wireless_latency_stats_info
+    - devices_wireless_radio_settings
+    - devices_wireless_radio_settings_info
+    - devices_wireless_status_info
+    - networks
+    - networks_alerts_history_info
+    - networks_alerts_settings
+    - networks_alerts_settings_info
+    - networks_appliance_connectivity_monitoring_destinations
+    - networks_appliance_connectivity_monitoring_destinations_info
+    - networks_appliance_content_filtering
+    - networks_appliance_content_filtering_categories_info
+    - networks_appliance_content_filtering_info
+    - networks_appliance_firewall_cellular_firewall_rules
+    - networks_appliance_firewall_cellular_firewall_rules_info
+    - networks_appliance_firewall_firewalled_services
+    - networks_appliance_firewall_firewalled_services_info
+    - networks_appliance_firewall_inbound_firewall_rules
+    - networks_appliance_firewall_inbound_firewall_rules_info
+    - networks_appliance_firewall_l3_firewall_rules
+    - networks_appliance_firewall_l3_firewall_rules_info
+    - networks_appliance_firewall_l7_firewall_rules
+    - networks_appliance_firewall_l7_firewall_rules_application_categories_info
+    - networks_appliance_firewall_l7_firewall_rules_info
+    - networks_appliance_firewall_one_to_many_nat_rules
+    - networks_appliance_firewall_one_to_many_nat_rules_info
+    - networks_appliance_firewall_one_to_one_nat_rules
+    - networks_appliance_firewall_one_to_one_nat_rules_info
+    - networks_appliance_firewall_port_forwarding_rules
+    - networks_appliance_firewall_port_forwarding_rules_info
+    - networks_appliance_firewall_settings
+    - networks_appliance_firewall_settings_info
+    - networks_appliance_ports
+    - networks_appliance_ports_info
+    - networks_appliance_prefixes_delegated_statics
+    - networks_appliance_prefixes_delegated_statics_info
+    - networks_appliance_rf_profiles
+    - networks_appliance_rf_profiles_info
+    - networks_appliance_security_intrusion
+    - networks_appliance_security_intrusion_info
+    - networks_appliance_security_malware
+    - networks_appliance_security_malware_info
+    - networks_appliance_settings
+    - networks_appliance_settings_info
+    - networks_appliance_single_lan
+    - networks_appliance_single_lan_info
+    - networks_appliance_ssids
+    - networks_appliance_ssids_info
+    - networks_appliance_static_routes
+    - networks_appliance_static_routes_info
+    - networks_appliance_traffic_shaping
+    - networks_appliance_traffic_shaping_custom_performance_classes
+    - networks_appliance_traffic_shaping_info
+    - networks_appliance_traffic_shaping_rules
+    - networks_appliance_traffic_shaping_rules_info
+    - networks_appliance_traffic_shaping_uplink_bandwidth
+    - networks_appliance_traffic_shaping_uplink_bandwidth_info
+    - networks_appliance_traffic_shaping_uplink_selection
+    - networks_appliance_traffic_shaping_uplink_selection_info
+    - networks_appliance_traffic_shaping_vpn_exclusions
+    - networks_appliance_vlans
+    - networks_appliance_vlans_info
+    - networks_appliance_vlans_settings
+    - networks_appliance_vlans_settings_info
+    - networks_appliance_vpn_bgp
+    - networks_appliance_vpn_bgp_info
+    - networks_appliance_vpn_site_to_site_vpn
+    - networks_appliance_vpn_site_to_site_vpn_info
+    - networks_appliance_warm_spare
+    - networks_appliance_warm_spare_info
+    - networks_appliance_warm_spare_swap
+    - networks_bind
+    - networks_bluetooth_clients_info
+    - networks_camera_quality_retention_profiles
+    - networks_camera_quality_retention_profiles_info
+    - networks_camera_wireless_profiles
+    - networks_camera_wireless_profiles_info
+    - networks_cellular_gateway_connectivity_monitoring_destinations
+    - networks_cellular_gateway_connectivity_monitoring_destinations_info
+    - networks_cellular_gateway_dhcp
+    - networks_cellular_gateway_dhcp_info
+    - networks_cellular_gateway_subnet_pool
+    - networks_cellular_gateway_subnet_pool_info
+    - networks_cellular_gateway_uplink
+    - networks_cellular_gateway_uplink_info
+    - networks_client_info
+    - networks_clients_info
+    - networks_clients_overview_info
+    - networks_clients_policy
+    - networks_clients_policy_info
+    - networks_clients_provision
+    - networks_clients_splash_authorization_status
+    - networks_clients_splash_authorization_status_info
+    - networks_devices_claim
+    - networks_devices_claim_vmx
+    - networks_devices_remove
+    - networks_events_event_types_info
+    - networks_events_info
+    - networks_firmware_upgrades
+    - networks_firmware_upgrades_info
+    - networks_firmware_upgrades_rollbacks
+    - networks_firmware_upgrades_staged_events
+    - networks_firmware_upgrades_staged_events_defer
+    - networks_firmware_upgrades_staged_events_info
+    - networks_firmware_upgrades_staged_events_rollbacks
+    - networks_firmware_upgrades_staged_groups
+    - networks_firmware_upgrades_staged_groups_info
+    - networks_firmware_upgrades_staged_stages
+    - networks_firmware_upgrades_staged_stages_info
+    - networks_floor_plans
+    - networks_floor_plans_info
+    - networks_group_policies
+    - networks_group_policies_info
+    - networks_health_alerts_info
+    - networks_info
+    - networks_insight_applications_health_by_time_info
+    - networks_meraki_auth_users
+    - networks_meraki_auth_users_info
+    - networks_mqtt_brokers
+    - networks_netflow
+    - networks_netflow_info
+    - networks_pii_pii_keys_info
+    - networks_pii_requests_delete
+    - networks_pii_requests_info
+    - networks_pii_sm_devices_for_key_info
+    - networks_pii_sm_owners_for_key_info
+    - networks_policies_by_client_info
+    - networks_sensor_alerts_current_overview_by_metric_info
+    - networks_sensor_alerts_overview_by_metric_info
+    - networks_sensor_alerts_profiles
+    - networks_sensor_alerts_profiles_info
+    - networks_sensor_mqtt_brokers
+    - networks_sensor_mqtt_brokers_info
+    - networks_sensor_relationships_info
+    - networks_settings
+    - networks_settings_info
+    - networks_sm_bypass_activation_lock_attempts
+    - networks_sm_bypass_activation_lock_attempts_info
+    - networks_sm_devices_cellular_usage_history_info
+    - networks_sm_devices_certs_info
+    - networks_sm_devices_checkin
+    - networks_sm_devices_connectivity_info
+    - networks_sm_devices_desktop_logs_info
+    - networks_sm_devices_device_command_logs_info
+    - networks_sm_devices_device_profiles_info
+    - networks_sm_devices_fields
+    - networks_sm_devices_info
+    - networks_sm_devices_install_apps
+    - networks_sm_devices_lock
+    - networks_sm_devices_modify_tags
+    - networks_sm_devices_move
+    - networks_sm_devices_network_adapters_info
+    - networks_sm_devices_performance_history_info
+    - networks_sm_devices_reboot
+    - networks_sm_devices_refresh_details
+    - networks_sm_devices_security_centers_info
+    - networks_sm_devices_shutdown
+    - networks_sm_devices_unenroll
+    - networks_sm_devices_uninstall_apps
+    - networks_sm_devices_wipe
+    - networks_sm_devices_wlan_lists_info
+    - networks_sm_profiles_info
+    - networks_sm_target_groups
+    - networks_sm_target_groups_info
+    - networks_sm_trusted_access_configs_info
+    - networks_sm_user_access_devices_delete
+    - networks_sm_user_access_devices_info
+    - networks_sm_users_device_profiles_info
+    - networks_sm_users_info
+    - networks_sm_users_softwares_info
+    - networks_snmp
+    - networks_snmp_info
+    - networks_split
+    - networks_switch_access_control_lists
+    - networks_switch_access_control_lists_info
+    - networks_switch_access_policies
+    - networks_switch_access_policies_info
+    - networks_switch_alternate_management_interface
+    - networks_switch_alternate_management_interface_info
+    - networks_switch_dhcp_server_policy
+    - networks_switch_dhcp_server_policy_arp_inspection_trusted_servers
+    - networks_switch_dhcp_server_policy_arp_inspection_trusted_servers_info
+    - networks_switch_dhcp_server_policy_arp_inspection_warnings_by_device_info
+    - networks_switch_dhcp_server_policy_info
+    - networks_switch_dhcp_v4_servers_seen_info
+    - networks_switch_dscp_to_cos_mappings
+    - networks_switch_dscp_to_cos_mappings_info
+    - networks_switch_link_aggregations
+    - networks_switch_link_aggregations_info
+    - networks_switch_mtu
+    - networks_switch_mtu_info
+    - networks_switch_port_schedules
+    - networks_switch_port_schedules_info
+    - networks_switch_qos_rules_order
+    - networks_switch_qos_rules_order_info
+    - networks_switch_routing_multicast
+    - networks_switch_routing_multicast_info
+    - networks_switch_routing_multicast_rendezvous_points
+    - networks_switch_routing_multicast_rendezvous_points_info
+    - networks_switch_routing_ospf
+    - networks_switch_routing_ospf_info
+    - networks_switch_settings
+    - networks_switch_settings_info
+    - networks_switch_stacks
+    - networks_switch_stacks_add
+    - networks_switch_stacks_info
+    - networks_switch_stacks_remove
+    - networks_switch_stacks_routing_interfaces
+    - networks_switch_stacks_routing_interfaces_dhcp
+    - networks_switch_stacks_routing_interfaces_dhcp_info
+    - networks_switch_stacks_routing_interfaces_info
+    - networks_switch_stacks_routing_static_routes
+    - networks_switch_stacks_routing_static_routes_info
+    - networks_switch_storm_control
+    - networks_switch_storm_control_info
+    - networks_switch_stp
+    - networks_switch_stp_info
+    - networks_syslog_servers
+    - networks_syslog_servers_info
+    - networks_topology_link_layer_info
+    - networks_traffic_analysis
+    - networks_traffic_analysis_info
+    - networks_traffic_shaping_application_categories_info
+    - networks_traffic_shaping_dscp_tagging_options_info
+    - networks_unbind
+    - networks_vlan_profiles
+    - networks_vlan_profiles_assignments_by_device_info
+    - networks_vlan_profiles_assignments_reassign
+    - networks_vlan_profiles_info
+    - networks_webhooks_http_servers
+    - networks_webhooks_http_servers_info
+    - networks_webhooks_payload_templates
+    - networks_webhooks_payload_templates_info
+    - networks_webhooks_webhook_tests_info
+    - networks_wireless_alternate_management_interface
+    - networks_wireless_alternate_management_interface_info
+    - networks_wireless_billing
+    - networks_wireless_billing_info
+    - networks_wireless_bluetooth_settings
+    - networks_wireless_bluetooth_settings_info
+    - networks_wireless_channel_utilization_history_info
+    - networks_wireless_client_count_history_info
+    - networks_wireless_clients_connection_stats_info
+    - networks_wireless_clients_latency_stats_info
+    - networks_wireless_connection_stats_info
+    - networks_wireless_data_rate_history_info
+    - networks_wireless_devices_connection_stats_info
+    - networks_wireless_ethernet_ports_profiles
+    - networks_wireless_ethernet_ports_profiles_assign
+    - networks_wireless_ethernet_ports_profiles_info
+    - networks_wireless_ethernet_ports_profiles_set_default
+    - networks_wireless_failed_connections_info
+    - networks_wireless_latency_history_info
+    - networks_wireless_latency_stats_info
+    - networks_wireless_mesh_statuses_info
+    - networks_wireless_rf_profiles
+    - networks_wireless_rf_profiles_info
+    - networks_wireless_settings
+    - networks_wireless_settings_info
+    - networks_wireless_signal_quality_history_info
+    - networks_wireless_ssids
+    - networks_wireless_ssids_bonjour_forwarding
+    - networks_wireless_ssids_bonjour_forwarding_info
+    - networks_wireless_ssids_device_type_group_policies
+    - networks_wireless_ssids_device_type_group_policies_info
+    - networks_wireless_ssids_eap_override
+    - networks_wireless_ssids_eap_override_info
+    - networks_wireless_ssids_firewall_l3_firewall_rules
+    - networks_wireless_ssids_firewall_l3_firewall_rules_info
+    - networks_wireless_ssids_firewall_l7_firewall_rules
+    - networks_wireless_ssids_firewall_l7_firewall_rules_info
+    - networks_wireless_ssids_hotspot20
+    - networks_wireless_ssids_hotspot20_info
+    - networks_wireless_ssids_identity_psks
+    - networks_wireless_ssids_identity_psks_info
+    - networks_wireless_ssids_info
+    - networks_wireless_ssids_schedules
+    - networks_wireless_ssids_schedules_info
+    - networks_wireless_ssids_splash_settings
+    - networks_wireless_ssids_splash_settings_info
+    - networks_wireless_ssids_traffic_shaping_rules
+    - networks_wireless_ssids_traffic_shaping_rules_info
+    - networks_wireless_ssids_vpn
+    - networks_wireless_ssids_vpn_info
+    - networks_wireless_usage_history_info
+    - organizations
+    - organizations_action_batches
+    - organizations_action_batches_info
+    - organizations_adaptive_policy_acls
+    - organizations_adaptive_policy_acls_info
+    - organizations_adaptive_policy_groups
+    - organizations_adaptive_policy_groups_info
+    - organizations_adaptive_policy_overview_info
+    - organizations_adaptive_policy_policies
+    - organizations_adaptive_policy_policies_info
+    - organizations_adaptive_policy_settings
+    - organizations_adaptive_policy_settings_info
+    - organizations_admins
+    - organizations_admins_info
+    - organizations_alerts_profiles
+    - organizations_api_requests_info
+    - organizations_api_requests_overview_info
+    - organizations_api_requests_overview_response_codes_by_interval_info
+    - organizations_appliance_security_intrusion
+    - organizations_appliance_security_intrusion_info
+    - organizations_appliance_traffic_shaping_vpn_exclusions_by_network_info
+    - organizations_appliance_uplinks_statuses_overview_info
+    - organizations_appliance_uplinks_usage_by_network_info
+    - organizations_appliance_vpn_third_party_vpnpeers
+    - organizations_appliance_vpn_third_party_vpnpeers_info
+    - organizations_appliance_vpn_vpn_firewall_rules
+    - organizations_appliance_vpn_vpn_firewall_rules_info
+    - organizations_branding_policies
+    - organizations_branding_policies_info
+    - organizations_branding_policies_priorities
+    - organizations_branding_policies_priorities_info
+    - organizations_camera_boundaries_areas_by_device_info
+    - organizations_camera_boundaries_lines_by_device_info
+    - organizations_camera_custom_analytics_artifacts
+    - organizations_camera_custom_analytics_artifacts_info
+    - organizations_camera_detections_history_by_boundary_by_interval_info
+    - organizations_camera_permissions_info
+    - organizations_camera_roles
+    - organizations_camera_roles_info
+    - organizations_cellular_gateway_uplink_statuses_info
+    - organizations_claim
+    - organizations_clients_bandwidth_usage_history_info
+    - organizations_clients_overview_info
+    - organizations_clients_search_info
+    - organizations_clone
+    - organizations_config_templates
+    - organizations_config_templates_info
+    - organizations_config_templates_switch_profiles_info
+    - organizations_config_templates_switch_profiles_ports
+    - organizations_config_templates_switch_profiles_ports_info
+    - organizations_devices_availabilities_change_history_info
+    - organizations_devices_availabilities_info
+    - organizations_devices_boots_history_info
+    - organizations_devices_info
+    - organizations_devices_power_modules_statuses_by_device_info
+    - organizations_devices_provisioning_statuses_info
+    - organizations_devices_statuses_info
+    - organizations_devices_statuses_overview_info
+    - organizations_devices_uplinks_addresses_by_device_info
+    - organizations_devices_uplinks_loss_and_latency_info
+    - organizations_early_access_features_info
+    - organizations_early_access_features_opt_ins
+    - organizations_early_access_features_opt_ins_info
+    - organizations_firmware_upgrades_by_device_info
+    - organizations_firmware_upgrades_info
+    - organizations_info
+    - organizations_insight_applications_info
+    - organizations_insight_monitored_media_servers
+    - organizations_insight_monitored_media_servers_info
+    - organizations_inventory_claim
+    - organizations_inventory_devices_info
+    - organizations_inventory_onboarding_cloud_monitoring_export_events
+    - organizations_inventory_onboarding_cloud_monitoring_imports
+    - organizations_inventory_onboarding_cloud_monitoring_imports_info
+    - organizations_inventory_onboarding_cloud_monitoring_networks_info
+    - organizations_inventory_onboarding_cloud_monitoring_prepare
+    - organizations_inventory_release
+    - organizations_licenses
+    - organizations_licenses_assign_seats
+    - organizations_licenses_info
+    - organizations_licenses_move
+    - organizations_licenses_move_seats
+    - organizations_licenses_overview_info
+    - organizations_licenses_renew_seats
+    - organizations_licensing_coterm_licenses_info
+    - organizations_licensing_coterm_licenses_move
+    - organizations_login_security
+    - organizations_login_security_info
+    - organizations_networks_combine
+    - organizations_openapi_spec_info
+    - organizations_policy_objects
+    - organizations_policy_objects_groups
+    - organizations_policy_objects_groups_info
+    - organizations_policy_objects_info
+    - organizations_saml
+    - organizations_saml_idps
+    - organizations_saml_idps_info
+    - organizations_saml_info
+    - organizations_saml_roles
+    - organizations_saml_roles_info
+    - organizations_sensor_readings_history_info
+    - organizations_sensor_readings_latest_info
+    - organizations_sm_admins_roles
+    - organizations_sm_admins_roles_info
+    - organizations_sm_apns_cert_info
+    - organizations_sm_sentry_policies_assignments
+    - organizations_sm_sentry_policies_assignments_by_network_info
+    - organizations_sm_vpp_accounts_info
+    - organizations_snmp
+    - organizations_snmp_info
+    - organizations_summary_top_appliances_by_utilization_info
+    - organizations_summary_top_clients_by_usage_info
+    - organizations_summary_top_clients_manufacturers_by_usage_info
+    - organizations_summary_top_devices_by_usage_info
+    - organizations_summary_top_devices_models_by_usage_info
+    - organizations_summary_top_networks_by_status_info
+    - organizations_summary_top_ssids_by_usage_info
+    - organizations_summary_top_switches_by_energy_usage_info
+    - organizations_switch_devices_clone
+    - organizations_switch_ports_by_switch_info
+    - organizations_uplinks_statuses_info
+    - organizations_users
+    - organizations_webhooks_callbacks_statuses_info
+    - organizations_webhooks_logs_info
+    - organizations_wireless_devices_channel_utilization_by_device_info
+    - organizations_wireless_devices_channel_utilization_by_network_info
+    - organizations_wireless_devices_channel_utilization_history_by_device_by_interval_info
+    - organizations_wireless_devices_channel_utilization_history_by_network_by_interval_info
+    - organizations_wireless_devices_ethernet_statuses_info
+    - organizations_wireless_devices_packet_loss_by_client_info
+    - organizations_wireless_devices_packet_loss_by_device_info
+    - organizations_wireless_devices_packet_loss_by_network_info
 
 plugin_routing:
-    modules:
-        meraki_ms_switchport:
-            deprecation:
-                removal_version: 3.0.0
-                warning_text: Use cisco.meraki.devices_switch_ports instead.
-        meraki_action_batch:
-            deprecation:
-                removal_version: 3.0.0
-                warning_text: Use cisco.meraki.organizations_action_batches instead.
-        meraki_admin:
-            deprecation:
-                removal_version: 3.0.0
-                warning_text: Use cisco.meraki.organizations_admins instead.
-        meraki_alert:
-            deprecation:
-                removal_version: 3.0.0
-                warning_text: Use cisco.meraki.networks_alerts_settings instead.
-        meraki_config_template:
-            deprecation:
-                removal_version: 3.0.0
-                warning_text: Use cisco.meraki.organizations_config_templates instead.
-        meraki_device:
-            deprecation:
-                removal_version: 3.0.0
-                warning_text: Use cisco.meraki.networks_devices_claim, cisco.meraki.networks_devices_remove and cisco.meraki.networks instead.
-        meraki_firewalled_services:
-            deprecation:
-                removal_version: 3.0.0
-                warning_text: Use cisco.meraki.networks_appliance_firewall_firewalled_services instead.
-        meraki_management_interface:
-            deprecation:
-                removal_version: 3.0.0
-                warning_text: Use cisco.meraki.devices_management_interface instead.
-        meraki_mr_l3_firewall:
-            deprecation:
-                removal_version: 3.0.0
-                warning_text: Use cisco.meraki.networks_appliance_firewall_l3_firewall_rules instead.
-        meraki_mr_l7_firewall:
-            deprecation:
-                removal_version: 3.0.0
-                warning_text: Use cisco.meraki.networks_appliance_firewall_l7_firewall_rules instead.
-        meraki_mr_radio:
-            deprecation:
-                removal_version: 3.0.0
-                warning_text: Use cisco.meraki.devices_wireless_radio_settings instead.
-        meraki_mr_rf_profile:
-            deprecation:
-                removal_version: 3.0.0
-                warning_text: Use cisco.meraki.networks_wireless_rf_profiles instead.
-        meraki_mr_settings:
-            deprecation:
-                removal_version: 3.0.0
-                warning_text: Use cisco.meraki.networks_wireless_settings instead.
-        meraki_mr_ssid:
-            deprecation:
-                removal_version: 3.0.0
-                warning_text: Use cisco.meraki.networks_wireless_ssids instead.
-        meraki_ms_access_list:
-            deprecation:
-                removal_version: 3.0.0
-                warning_text: Use cisco.meraki.networks_switch_access_control_lists instead.
-        meraki_ms_access_policies:
-            deprecation:
-                removal_version: 3.0.0
-                warning_text: Use cisco.meraki.networks_switch_access_policies instead.
-        meraki_ms_l3_interface:
-            deprecation:
-                removal_version: 3.0.0
-                warning_text: Use cisco.meraki.devices_switch_routing_interfaces instead.
-        meraki_ms_link_aggregation:
-            deprecation:
-                removal_version: 3.0.0
-                warning_text: Use cisco.meraki.networks_switch_link_aggregations instead.
-        meraki_ms_ospf:
-            deprecation:
-                removal_version: 3.0.0
-                warning_text: Use cisco.meraki.networks_switch_routing_ospf instead.
-        meraki_ms_stack_l3_interface:
-            deprecation:
-                removal_version: 3.0.0
-                warning_text: Use cisco.meraki.networks_switch_stacks_routing_interfaces instead.
-        meraki_ms_stack:
-            deprecation:
-                removal_version: 3.0.0
-                warning_text: Use cisco.meraki.networks_switch_stacks instead.
-        meraki_ms_storm_control:
-            deprecation:
-                removal_version: 3.0.0
-                warning_text: Use cisco.meraki.networks_switch_storm_control instead.
-        meraki_mx_content_filtering:
-            deprecation:
-                removal_version: 3.0.0
-                warning_text: Use cisco.meraki.networks_appliance_content_filtering instead.
-        meraki_mx_intrusion_prevention:
-            deprecation:
-                removal_version: 3.0.0
-                warning_text: Use cisco.meraki.organizations_appliance_security_intrusion and cisco.meraki.networks_appliance_security_intrusion instead.
-        meraki_mx_l2_interface:
-            deprecation:
-                removal_version: 3.0.0
-                warning_text: Use cisco.meraki.networks_appliance_ports instead.
-        meraki_mx_l3_firewall:
-            deprecation:
-                removal_version: 3.0.0
-                warning_text: Use cisco.meraki.networks_appliance_firewall_l3_firewall_rules instead.
-        meraki_mx_l7_firewall:
-            deprecation:
-                removal_version: 3.0.0
-                warning_text: Use cisco.meraki.networks_appliance_firewall_l7_firewall_rules instead.
-        meraki_mx_malware:
-            deprecation:
-                removal_version: 3.0.0
-                warning_text: Use cisco.meraki.networks_appliance_security_malware instead.
-        meraki_mx_nat:
-            deprecation:
-                removal_version: 3.0.0
-                warning_text: Use cisco.meraki.networks_appliance_firewall_one_to_many_nat_rules instead.
-        meraki_mx_network_vlan_settings:
-            deprecation:
-                removal_version: 3.0.0
-                warning_text: Use cisco.meraki.networks_appliance_vlans_settings instead.
-        meraki_mx_site_to_site_firewall:
-            deprecation:
-                removal_version: 3.0.0
-                warning_text: Use cisco.meraki.organizations_appliance_vpn_vpn_firewall_rules instead.
-        meraki_mx_site_to_site_vpn:
-            deprecation:
-                removal_version: 3.0.0
-                warning_text: Use cisco.meraki.networks_appliance_vpn_site_to_site_vpn instead.
-        meraki_mx_static_route:
-            deprecation:
-                removal_version: 3.0.0
-                warning_text: Use cisco.meraki.networks_appliance_static_routes instead.
-        meraki_mx_third_party_vpn_peers:
-            deprecation:
-                removal_version: 3.0.0
-                warning_text: Use cisco.meraki.organizations_appliance_vpn_third_party_vpnpeers instead.
-        meraki_mx_uplink_bandwidth:
-            deprecation:
-                removal_version: 3.0.0
-                warning_text: Use cisco.meraki.networks_appliance_traffic_shaping_uplink_bandwidth instead.
-        meraki_mx_vlan:
-            deprecation:
-                removal_version: 3.0.0
-                warning_text: Use cisco.meraki.networks_appliance_vlans instead.
-        meraki_network_settings:
-            deprecation:
-                removal_version: 3.0.0
-                warning_text: Use cisco.meraki.networks_settings instead.
-        meraki_network:
-            deprecation:
-                removal_version: 3.0.0
-                warning_text: Use cisco.meraki.networks instead.
-        meraki_organization:
-            deprecation:
-                removal_version: 3.0.0
-                warning_text: Use cisco.meraki.organizations instead.
-        meraki_snmp:
-            deprecation:
-                removal_version: 3.0.0
-                warning_text: Use cisco.meraki.networks_snmp instead.
-        meraki_syslog:
-            deprecation:
-                removal_version: 3.0.0
-                warning_text: Use cisco.meraki.networks_syslog_servers instead.
-        meraki_webhook_payload_template:
-            deprecation:
-                removal_version: 3.0.0
-                warning_text: Use cisco.meraki.networks_webhooks_payload_templates instead.
-        meraki_webhook:
-            deprecation:
-                removal_version: 3.0.0
-                warning_text: Use cisco.meraki.networks_webhooks_http_servers instead.
+  modules:
+    meraki_ms_switchport:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Use cisco.meraki.devices_switch_ports instead.
+    meraki_action_batch:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Use cisco.meraki.organizations_action_batches instead.
+    meraki_admin:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Use cisco.meraki.organizations_admins instead.
+    meraki_alert:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Use cisco.meraki.networks_alerts_settings instead.
+    meraki_config_template:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Use cisco.meraki.organizations_config_templates instead.
+    meraki_device:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Use cisco.meraki.networks_devices_claim, cisco.meraki.networks_devices_remove and cisco.meraki.networks instead.
+    meraki_firewalled_services:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Use cisco.meraki.networks_appliance_firewall_firewalled_services instead.
+    meraki_management_interface:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Use cisco.meraki.devices_management_interface instead.
+    meraki_mr_l3_firewall:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Use cisco.meraki.networks_appliance_firewall_l3_firewall_rules instead.
+    meraki_mr_l7_firewall:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Use cisco.meraki.networks_appliance_firewall_l7_firewall_rules instead.
+    meraki_mr_radio:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Use cisco.meraki.devices_wireless_radio_settings instead.
+    meraki_mr_rf_profile:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Use cisco.meraki.networks_wireless_rf_profiles instead.
+    meraki_mr_settings:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Use cisco.meraki.networks_wireless_settings instead.
+    meraki_mr_ssid:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Use cisco.meraki.networks_wireless_ssids instead.
+    meraki_ms_access_list:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Use cisco.meraki.networks_switch_access_control_lists instead.
+    meraki_ms_access_policies:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Use cisco.meraki.networks_switch_access_policies instead.
+    meraki_ms_l3_interface:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Use cisco.meraki.devices_switch_routing_interfaces instead.
+    meraki_ms_link_aggregation:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Use cisco.meraki.networks_switch_link_aggregations instead.
+    meraki_ms_ospf:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Use cisco.meraki.networks_switch_routing_ospf instead.
+    meraki_ms_stack_l3_interface:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Use cisco.meraki.networks_switch_stacks_routing_interfaces instead.
+    meraki_ms_stack:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Use cisco.meraki.networks_switch_stacks instead.
+    meraki_ms_storm_control:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Use cisco.meraki.networks_switch_storm_control instead.
+    meraki_mx_content_filtering:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Use cisco.meraki.networks_appliance_content_filtering instead.
+    meraki_mx_intrusion_prevention:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Use cisco.meraki.organizations_appliance_security_intrusion and cisco.meraki.networks_appliance_security_intrusion instead.
+    meraki_mx_l2_interface:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Use cisco.meraki.networks_appliance_ports instead.
+    meraki_mx_l3_firewall:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Use cisco.meraki.networks_appliance_firewall_l3_firewall_rules instead.
+    meraki_mx_l7_firewall:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Use cisco.meraki.networks_appliance_firewall_l7_firewall_rules instead.
+    meraki_mx_malware:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Use cisco.meraki.networks_appliance_security_malware instead.
+    meraki_mx_nat:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Use cisco.meraki.networks_appliance_firewall_one_to_many_nat_rules instead.
+    meraki_mx_network_vlan_settings:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Use cisco.meraki.networks_appliance_vlans_settings instead.
+    meraki_mx_site_to_site_firewall:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Use cisco.meraki.organizations_appliance_vpn_vpn_firewall_rules instead.
+    meraki_mx_site_to_site_vpn:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Use cisco.meraki.networks_appliance_vpn_site_to_site_vpn instead.
+    meraki_mx_static_route:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Use cisco.meraki.networks_appliance_static_routes instead.
+    meraki_mx_third_party_vpn_peers:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Use cisco.meraki.organizations_appliance_vpn_third_party_vpnpeers instead.
+    meraki_mx_uplink_bandwidth:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Use cisco.meraki.networks_appliance_traffic_shaping_uplink_bandwidth instead.
+    meraki_mx_vlan:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Use cisco.meraki.networks_appliance_vlans instead.
+    meraki_network_settings:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Use cisco.meraki.networks_settings instead.
+    meraki_network:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Use cisco.meraki.networks instead.
+    meraki_organization:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Use cisco.meraki.organizations instead.
+    meraki_snmp:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Use cisco.meraki.networks_snmp instead.
+    meraki_syslog:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Use cisco.meraki.networks_syslog_servers instead.
+    meraki_webhook_payload_template:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Use cisco.meraki.networks_webhooks_payload_templates instead.
+    meraki_webhook:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Use cisco.meraki.networks_webhooks_http_servers instead.


### PR DESCRIPTION
using action group to make use of module_defaults https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_module_defaults.html

with a action group a playbook can be simplified. while running multiple tasks in a playbook the vars have to be only referenced once

```
---
- name: meraki test
  hosts: meraki_server
  gather_facts: false
  module_defaults:
    group/cisco.meraki.meraki:
      meraki_api_key: "{{ meraki_api_key }}"
      meraki_suppress_logging: true

  tasks:
    - name: Get all Organizations
      cisco.meraki.organizations_info:
      register: result
    - name: debug
      ansible.builtin.debug:
        msg: "{{ result }}"
```