### PR TITLE
fixed wrong datatype in result for get_object_by_name()

### DIFF
--- a/plugins/action/networks_appliance_vlans_settings.py
+++ b/plugins/action/networks_appliance_vlans_settings.py
@@ -77,9 +77,6 @@ class NetworksApplianceVlansSettings(object):
                 function="getNetworkApplianceVlansSettings",
                 params=self.get_all_params(name=name),
             )
-            if isinstance(items, dict):
-                if 'vlansEnabled' in items:
-                    items = { "vlansEnabled": items.get('vlansEnabled') }
             result = get_dict_result(items, 'name', name)
             if result is None:
                 result = items

--- a/plugins/action/networks_appliance_vlans_settings.py
+++ b/plugins/action/networks_appliance_vlans_settings.py
@@ -79,7 +79,7 @@ class NetworksApplianceVlansSettings(object):
             )
             if isinstance(items, dict):
                 if 'vlansEnabled' in items:
-                    items = items.get('vlansEnabled')
+                    items = { "vlansEnabled": items.get('vlansEnabled') }
             result = get_dict_result(items, 'name', name)
             if result is None:
                 result = items


### PR DESCRIPTION
Fixes #82 resolving the issue where `items = items.get('vlansEnabled')` has the wrong data type for its value.  The variable `items` should contain a dict, not a boolean value.