### PR TITLE
fixed wrong datatype in result for get_object_by_name()

### DIFF
--- a/plugins/action/networks_appliance_firewall_l3_firewall_rules.py
+++ b/plugins/action/networks_appliance_firewall_l3_firewall_rules.py
@@ -83,9 +83,6 @@ class NetworksApplianceFirewallL3FirewallRules(object):
                 function="getNetworkApplianceFirewallL3FirewallRules",
                 params=self.get_all_params(name=name),
             )
-            if isinstance(items, dict):
-                if 'rules' in items:
-                    items = items.get('rules')
             result = get_dict_result(items, 'name', name)
             if result is None:
                 result = items


### PR DESCRIPTION
Fixes #84 resolving the issue where items = items.get('rules') has the wrong data type for its value. The variable items should contain a dict, not a boolean value.