### PR TITLE
Add event counting query file

### DIFF
--- a/changelogs/fragments/event_query.yml
+++ b/changelogs/fragments/event_query.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - "Event counting - Adds a event query file to count indirectly managed objects."

--- a/extensions/audit/event_query.yml
+++ b/extensions/audit/event_query.yml
@@ -1,0 +1,16 @@
+---
+# Networks
+cisco.meraki.networks_info:
+  query: >-
+    .meraki_response | [.] | flatten |
+     map({
+        name: .name,
+        canonical_facts: {
+          ansible_meraki_network_id: .id,
+          ansible_meraki_org_id: .organizationId
+        },
+        facts: {
+          device_type: "network"
+        }
+      })
+    | .[]

--- a/extensions/audit/event_query.yml
+++ b/extensions/audit/event_query.yml
@@ -6,8 +6,8 @@ cisco.meraki.networks_info:
      map({
         name: .name,
         canonical_facts: {
-          ansible_meraki_network_id: .id,
-          ansible_meraki_org_id: .organizationId
+          network_id: .id,
+          org_id: .organizationId
         },
         facts: {
           device_type: "network"
@@ -23,8 +23,8 @@ cisco.meraki.networks:
       {
         name: .name,
         canonical_facts: {
-          ansible_meraki_network_id: .id,
-          ansible_meraki_org_id: .organizationId
+          network_id: .id,
+          org_id: .organizationId
         },
         facts: {
             device_type: "network"
@@ -32,3 +32,23 @@ cisco.meraki.networks:
       }
     else empty
     end
+
+# Devices
+cisco.meraki.devices_info:
+  query: >-
+    .meraki_response | [.] | flatten |
+      map({
+          name: ((.name | select(. != "")) // (.productType + "-" + .serial)),
+          canonical_facts: {
+            ansible_product_serial: .serial,
+            macaddress: .mac
+          },
+          facts: {
+            device_type: .productType,
+            meraki_network_id: .networkId,
+            ansible_hostname: (.lanIp // ""),
+            ansible_product_name: .model,
+            ansible_bios_version: .firmware,
+          }
+        })
+      | .[]

--- a/extensions/audit/event_query.yml
+++ b/extensions/audit/event_query.yml
@@ -18,8 +18,8 @@ cisco.meraki.networks_info:
 # delete operation returns "meraki_response": null
 cisco.meraki.networks:
   query: >-
-    if .meraki_response then 
-      .meraki_response | 
+    if .meraki_response then
+      .meraki_response |
       {
         name: .name,
         canonical_facts: {

--- a/extensions/audit/event_query.yml
+++ b/extensions/audit/event_query.yml
@@ -14,3 +14,21 @@ cisco.meraki.networks_info:
         }
       })
     | .[]
+
+# delete operation returns "meraki_response": null
+cisco.meraki.networks:
+  query: >-
+    if .meraki_response then 
+      .meraki_response | 
+      {
+        name: .name,
+        canonical_facts: {
+          ansible_meraki_network_id: .id,
+          ansible_meraki_org_id: .organizationId
+        },
+        facts: {
+            device_type: "network"
+        }
+      }
+    else empty
+    end


### PR DESCRIPTION
#### SUMMARY

- Adds an event query file to count indirectly managed objects.

**Note:** Here's a Python script to test it - https://gist.github.com/NilashishC/3b24d54768e2412cacc19f3364805a99

#### ISSUE TYPE
Feature Pull Request

#### COMPONENT NAME
event_counting