### PR TITLE
Add more connect parameters to the Meraki inventory plugin

### DIFF
--- a/plugins/inventory/meraki.py
+++ b/plugins/inventory/meraki.py
@@ -20,25 +20,117 @@ description:
   - Build inventories using the Cisco Meraki API.
   - Uses a YAML configuration file cisco_meraki.[yml|yaml].
 options:
-  meraki_api_key:
-    description:
-      - Specifies the Meraki API key,
-      - See the Cisco Meraki documentaion to obtain the API key
-        U(https://developer.cisco.com/meraki/api-v1/authorization/#obtaining-your-meraki-api-key).
-    type: str
-    required: true
   meraki_org_id:
     description:
       - The organization ID to fetch the networks and devices from.
     type: str
     required: true
+  meraki_api_key:
+    description:
+      - meraki_api_key (string), API key generated in dashboard; can also be set as an environment variable MERAKI_DASHBOARD_API_KEY
+    type: str
+  meraki_base_url:
+    description:
+        - meraki_base_url (string), preceding all endpoint resources
+    type: str
+    default: https://api.meraki.com/api/v1
+  meraki_single_request_timeout:
+    description:
+      - meraki_single_request_timeout (integer), maximum number of seconds for each API call
+    type: int
+    default: 60
+  meraki_certificate_path:
+    description:
+      - meraki_certificate_path (string), path for TLS/SSL certificate verification if behind local proxy
+    type: str
+    default: ''
+  meraki_requests_proxy:
+    description:
+      - meraki_requests_proxy (string), proxy server and port, if needed, for HTTPS
+    type: str
+    default: ''
+  meraki_wait_on_rate_limit:
+    description:
+      - meraki_wait_on_rate_limit (boolean), retry if 429 rate limit error encountered?
+    type: bool
+    default: true
+  meraki_nginx_429_retry_wait_time:
+    description:
+      - meraki_nginx_429_retry_wait_time (integer), Nginx 429 retry wait time
+    type: int
+    default: 60
+  meraki_action_batch_retry_wait_time:
+    description:
+      - meraki_action_batch_retry_wait_time (integer), action batch concurrency error retry wait time
+    type: int
+    default: 60
+  meraki_retry_4xx_error:
+    description:
+      - meraki_retry_4xx_error (boolean), retry if encountering other 4XX error (besides 429)?
+    type: bool
+    default: false
+  meraki_retry_4xx_error_wait_time:
+    description:
+      - meraki_retry_4xx_error_wait_time (integer), other 4XX error retry wait time
+    type: int
+    default: 60
+  meraki_maximum_retries:
+    description:
+      - meraki_maximum_retries (integer), retry up to this many times when encountering 429s or other server-side errors
+    type: int
+    default: 2
+  meraki_output_log:
+    description:
+      - meraki_output_log (boolean), create an output log file?
+    type: bool
+    default: true
+  meraki_log_file_prefix:
+    description:
+      - meraki_log_file_prefix (string), log file name appended with date and timestamp
+    type: str
+    default: meraki_api_
+  meraki_log_path:
+    description:
+      - log_path (string), path to output log; by default, working directory of script if not specified
+    type: str
+    default: ''
+  meraki_print_console:
+    description:
+      - meraki_print_console (boolean), print logging output to console?
+    type: bool
+    default: true
+  meraki_suppress_logging:
+    description:
+      - meraki_suppress_logging (boolean), disable all logging? you're on your own then!
+    type: bool
+    default: false
+  meraki_simulate:
+    description:
+      - meraki_simulate (boolean), simulate POST/PUT/DELETE calls to prevent changes?
+    type: bool
+    default: false
+  meraki_be_geo_id:
+    description:
+      - meraki_be_geo_id (string), optional partner identifier for API usage tracking; can also be set as an environment variable BE_GEO_ID
+    type: str
+    default: ''
+  meraki_use_iterator_for_get_pages:
+    description:
+      - meraki_use_iterator_for_get_pages (boolean), list* methods will return an iterator with each object instead of a complete list with all items
+    type: bool
+    default: false
+  meraki_inherit_logging_config:
+    description:
+      - meraki_inherit_logging_config (boolean), Inherits your own logger instance
+    type: bool
+    default: false
 """
 
 EXAMPLES = """
 # cisco_meraki.yml
 ---
 plugin: cisco.meraki.meraki
-meraki_api_key: "<enter Meraki API key>"
+meraki_api_key: "<enter Meraki API key or set the MERAKI_DASHBOARD_API_KEY env var>"
 meraki_org_id: "<enter Meraki Org ID>"
 keyed_groups:
   # group devices based on network ID
@@ -56,17 +148,16 @@ keyed_groups:
 """
 
 from ansible.errors import AnsibleError
+from ansible.module_utils.common.arg_spec import ArgumentSpecValidator
 from ansible.module_utils.common.text.converters import to_native, to_text
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable
-from ansible.module_utils.basic import missing_required_lib
+from ansible_collections.cisco.meraki.plugins.plugin_utils.meraki import (
+    MERAKI,
+    meraki_argument_spec,
+)
 
-
-try:
-    import meraki
-
-    HAS_MERAKI = True
-except ImportError:
-    HAS_MERAKI = False
+meraki_argument_spec = meraki_argument_spec()
+meraki_argument_spec.update(dict(meraki_org_id=dict(type="str", required=True)))
 
 
 class InventoryModule(BaseInventoryPlugin, Constructable):
@@ -83,46 +174,52 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
     def _build_network_map(self, dashboard, org_id):
         """Build a dictionary mapping network ID to network names."""
-        self._networks = {}
-        networks = dashboard.organizations.getOrganizationNetworks(
-            org_id, total_pages="all"
+        network_map = {}
+        networks = dashboard.exec_meraki(
+            family="organizations",
+            function="getOrganizationNetworks",
+            params={"organizationId": org_id, "total_pages": "all"}
         )
         for network in networks:
-            self._networks[network["id"]] = to_text(network.get("name", ""))
+            network_map[network["id"]] = to_text(network.get("name", ""))
+
+        return network_map
+
+    def _validate_argspec(self, parameters):
+        "Validate the inventory plugin argspec."
+        argspec_validator = ArgumentSpecValidator(meraki_argument_spec)
+        result = argspec_validator.validate(parameters)
+
+        if result.error_messages:
+            raise AnsibleError(f"Validation failed: {", ".join(result.error_messages)}")
+
+        return result.validated_parameters
 
     def parse(self, inventory, loader, path, cache=True):
         """Talk to the Meraki API and build the inventory."""
-        if not HAS_MERAKI:
-            # fail if meraki python library is not installed
-            raise AnsibleError(missing_required_lib("meraki"))
 
         # call base method to ensure properties are available for use with other helper methods
         super(InventoryModule, self).parse(inventory, loader, path, cache)
-        self._read_config_data(path)
 
-        meraki_api_key = self.get_option("meraki_api_key")
-        meraki_org_id = self.get_option("meraki_org_id")
+        config = self._read_config_data(path)
+        meraki_connect_config = {
+            k: config[k] for k in config if k in meraki_argument_spec
+        }
 
-        strict = self.get_option("strict")
-        keyed_groups = self.get_option("keyed_groups")
+        validated_config = self._validate_argspec(parameters=meraki_connect_config)
 
-        if not meraki_api_key:
-            raise AnsibleError("`meraki_api_key` option is not set or is empty.")
-        if not meraki_org_id:
-            raise AnsibleError("`meraki_org_id` option is not set or is empty.")
+        meraki_org_id = validated_config.pop("meraki_org_id")
 
-        dashboard = meraki.DashboardAPI(
-            api_key=meraki_api_key.strip(),
-            base_url="https://api.meraki.com/api/v1/",
-            output_log=False,
-            print_console=False,
-        )
+        dashboard = MERAKI(params=validated_config)
+
         try:
-            devices = dashboard.organizations.getOrganizationDevices(
-                meraki_org_id, total_pages="all"
+            devices = dashboard.exec_meraki(
+                family="organizations",
+                function="getOrganizationDevices",
+                params={"organizationId": meraki_org_id},
             )
             if devices:
-                self._build_network_map(dashboard, meraki_org_id)
+                network_map = self._build_network_map(dashboard, meraki_org_id)
 
                 for device in devices:
                     hostname = device.get("name")
@@ -138,8 +235,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                             hostname, "network_id", device["networkId"]
                         )
                         self.inventory.set_variable(
-                            hostname, "network",
-                            self._networks[device["networkId"]]
+                            hostname, "network", network_map[device["networkId"]]
                         )
                     else:
                         self.display.vvvv(
@@ -167,10 +263,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
                     # Add the host to the keyed groups
                     self._add_host_to_keyed_groups(
-                        keys=keyed_groups,
+                        keys=self.get_option("keyed_groups"),
                         variables=device,
                         host=hostname,
-                        strict=strict,
+                        strict=self.get_option("strict"),
                     )
         except Exception as e:
             raise AnsibleError(f"Failed to get devices from Meraki API: {to_native(e)}")

--- a/plugins/inventory/meraki.py
+++ b/plugins/inventory/meraki.py
@@ -216,7 +216,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             devices = dashboard.exec_meraki(
                 family="organizations",
                 function="getOrganizationDevices",
-                params={"organizationId": meraki_org_id},
+                params={"organizationId": meraki_org_id, "total_pages": "all"},
             )
             if devices:
                 network_map = self._build_network_map(dashboard, meraki_org_id)

--- a/plugins/inventory/meraki.py
+++ b/plugins/inventory/meraki.py
@@ -191,7 +191,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         result = argspec_validator.validate(parameters)
 
         if result.error_messages:
-            raise AnsibleError(f"Validation failed: {", ".join(result.error_messages)}")
+            raise AnsibleError(f"Validation failed: {', '.join(result.error_messages)}")
 
         return result.validated_parameters
 


### PR DESCRIPTION
#### Summary

- This PR adds all the Meraki dashboard connect options to the Inventory plugin as well.

- This also uses the Meraki SDK wrapper (used by all the modules) instead of interacting with the SDK directly.

- **Note:** I could not leverage `extends_doc_fragments` to reuse the `module_info` doc fragment since it sets `meraki_api_key` as a required variable. This does not work when the API key is set via the environment variable (and not specified in the inventory source file) for the inventory plugin. I copied all the options in the doc fragment and remove `required: True` from the `meraki_api_key` option.