### PR TITLE
Fix for issue #119 (Idempotency check fails, resulting in zero ability to configure appliance uplink bandwidth via ansible collection.

### DIFF
--- a/plugins/action/networks_appliance_traffic_shaping_uplink_bandwidth.py
+++ b/plugins/action/networks_appliance_traffic_shaping_uplink_bandwidth.py
@@ -20,7 +20,7 @@ from ansible.errors import AnsibleActionFail
 from ansible_collections.cisco.meraki.plugins.plugin_utils.meraki import (
     MERAKI,
     meraki_argument_spec,
-    meraki_compare_equality2,
+    meraki_compare_equality,
     get_dict_result,
 )
 from ansible_collections.cisco.meraki.plugins.plugin_utils.exceptions import (
@@ -126,7 +126,7 @@ class NetworksApplianceTrafficShapingUplinkBandwidth(object):
         ]
         # Method 1. Params present in request (Ansible) obj are the same as the current (ISE) params
         # If any does not have eq params, it requires update
-        return any(not meraki_compare_equality2(current_obj.get(meraki_param),
+        return any(not meraki_compare_equality(current_obj.get(meraki_param),
                                                 requested_obj.get(ansible_param))
                    for (meraki_param, ansible_param) in obj_params)
 


### PR DESCRIPTION
This PR addresses issue #119 

(https://github.com/meraki/dashboard-api-ansible/issues/119)

The solution is to change the payload equality check function being used. This has been tested and validated. It fixed the issue allowing the collection to successfully configure uplink bandwidth traffic shaping. 

Associated module: https://docs.ansible.com/ansible/latest/collections/cisco/meraki/networks_appliance_traffic_shaping_uplink_bandwidth_module.html#ansible-collections-cisco-meraki-networks-appliance-traffic-shaping-uplink-bandwidth-module