### PR TITLE
Update CHANGELOG and README for v2.23.1 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,16 @@ Cisco.Meraki Release Notes
 ==========================
 
 .. contents:: Topics
+
+v2.23.1
+=======
+
+Bugfixes
+--------
+
+- Fixing problem of naming in organizations_appliance_vpn_third_party_vpnpeers_info.
+- Restructuring README.md file.
+
 v2.23.0
 =======
 

--- a/README.md
+++ b/README.md
@@ -2,162 +2,251 @@
 
 The Meraki-Ansible project provides an Ansible collection for managing and automating your Cisco Meraki environment. It consists of a set of modules and roles for performing tasks related to Meraki.
 
-# Quick Start Guide
+## Requirements
+
+- Ansible >= 2.14
+- [Python Meraki SDK](https://github.com/meraki/dashboard-api-python) v1.33.0 or newer
+- Python >= 3.6, as the Meraki SDK doesn't support Python version 2.x
 
 ## Installation
-1. Ansible must be installed just in case needed. Check if your environment does not provide it. Example AAP. ([Install guide](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html))
+
+1. Install the collection from Ansible Automation Hub or Galaxy:
+
 ```
-pip install ansible-core
+ansible-galaxy collection install cisco.meraki -f
 ```
 
-2. Python Meraki SDK must be installed
+2. Install the Python Meraki SDK:
+
 ```
 pip install meraki
 ```
 
-3. Install the collection ([Galaxy link](https://galaxy.ansible.com/cisco/meraki))
-```
-ansible-galaxy collection install cisco.meraki -f
-```
-## Initial Configuration
+3. Make your Meraki API key available to the playbook. You can use an environment variable:
 
-1. First, your Meraki API key needs to be available for the playbook to use. You can leverage environment variables `export MERAKI_DASHBOARD_API_KEY=6bec40cf957de430a6f1f2baa056b99a4fac9ea0`, or create a `credentials.yml` ([example](https://github.com/meraki/dashboard-api-ansible/blob/main/playbooks/credentials.yml) file.
-**Note:** Storing your API key in an unencrypted text file is not recommended for security reasons.
-2. Create a `hosts` ([example](https://github.com/meraki/dashboard-api-ansible/blob/main/playbooks/hosts)) file that uses `[meraki_servers]` with your Cisco Meraki Settings:
+```
+export MERAKI_DASHBOARD_API_KEY=<your_api_key>
+```
+
+> **Note:** Storing your API key in an unencrypted text file is not recommended for security reasons. Consider using Ansible Vault or AAP credentials.
+
+4. Create a `hosts` ([example](https://github.com/meraki/dashboard-api-ansible/blob/main/playbooks/hosts)) file:
+
 ```
 [meraki_servers]
 meraki_server
 ```
-3. Running your first "Hello, world" in Ansible
-Create a playbook `who_am_i.yml` ([example](https://github.com/meraki/dashboard-api-ansible/blob/main/playbooks/who_am_i.yml)):
-```
+
+## Use Cases
+
+### 1. Retrieve administrator identity
+
+Verify which Meraki admin account is being used by the API key:
+
+```yaml
 ---
-- name: Play Name
+- name: Get administered identities
   hosts: meraki_servers
   gather_facts: false
   tasks:
     - name: Get my administered identities
       cisco.meraki.administered_identities_me_info:
+        meraki_api_key: "{{ meraki_api_key }}"
       register: result
 
     - name: Show result
       ansible.builtin.debug:
         msg: "{{ result }}"
 ```
-This is a simple playbook that will (1) get the information about the Meraki admin user the API key belongs to and (2) print the information on the screen.
 
-Execute the playbook:
+### 2. Manage network webhooks
+
+Create an HTTP server webhook for a Meraki network to receive alert notifications:
+
+```yaml
+---
+- name: Configure network webhook
+  hosts: meraki_servers
+  gather_facts: false
+  tasks:
+    - name: Create webhook
+      cisco.meraki.networks_webhooks_http_servers:
+        meraki_api_key: "{{ meraki_api_key }}"
+        state: present
+        name: MyWebhook
+        networkId: "{{ network_id }}"
+        payloadTemplate:
+          name: Slack (included)
+          payloadTemplateId: wpt_00001
+        sharedSecret: "{{ webhook_secret }}"
+        url: https://webhook.example.com/
 ```
-ansible-playbook -i hosts who_am_i.yml
+
+### 3. Configure wireless settings
+
+Enable or disable multicast-to-unicast conversion for a network's wireless settings:
+
+```yaml
+---
+- name: Update wireless settings
+  hosts: meraki_servers
+  gather_facts: false
+  tasks:
+    - name: Enable multicast-to-unicast conversion
+      cisco.meraki.networks_wireless_settings:
+        meraki_api_key: "{{ meraki_api_key }}"
+        state: present
+        networkId: "{{ network_id }}"
+        ipv6BridgeEnabled: false
+        locationAnalyticsEnabled: false
+        meshingEnabled: true
+        upgradeStrategy: minimizeUpgradeTime
 ```
-4. Congratulations! You have just run your first Ansible playbook!
 
-- - -
-# Detailed Information
+### 4. Query organization inventory
 
-This collection has been tested and supports Cisco Meraki Dashboard API v1.33.0
+Retrieve device inventory for an organization, including End-of-Life status information:
 
-*Note: This collection is not compatible with versions of Ansible before v2.14.*
+```yaml
+---
+- name: Get organization inventory
+  hosts: meraki_servers
+  gather_facts: false
+  tasks:
+    - name: Retrieve inventory devices
+      cisco.meraki.organizations_inventory_devices_info:
+        meraki_api_key: "{{ meraki_api_key }}"
+        organizationId: "{{ org_id }}"
+      register: inventory
 
-Other versions of this collection have support for previous Cisco Meraki versions. The recommended versions are listed below on the [Compatibility matrix](https://github.com/meraki/dashboard-api-ansible#compatibility-matrix).
+    - name: Show inventory
+      ansible.builtin.debug:
+        msg: "{{ inventory }}"
+```
 
-## Compatibility matrix
+### 5. Manage organization appliance VPN peers
 
-| Cisco Meraki version | Ansible "cisco.meraki" version | Python "DashboardAPI" version |
-|--------------------------|------------------------------|-------------------------------|
-| 1.33.0                    | 2.17.0                      |1.33.0                         |
-| 1.44.1                    | 2.18.3                      |1.44.1                         |
-| 1.53.0                    | 2.20.8                      |1.53.0                         |
-| 1.57.0                    | 2.21.2                      |1.57.0                         |
+Configure third-party VPN peers for an organization's appliances:
+
+```yaml
+---
+- name: Configure third-party VPN peers
+  hosts: meraki_servers
+  gather_facts: false
+  tasks:
+    - name: Update VPN peers
+      cisco.meraki.organizations_appliance_vpn_third_party_vpn_peers:
+        meraki_api_key: "{{ meraki_api_key }}"
+        state: present
+        organizationId: "{{ org_id }}"
+        peers:
+          - name: RemoteSite
+            publicIp: 198.51.100.1
+            privateSubnets:
+              - 192.168.100.0/24
+            secret: "{{ vpn_secret }}"
+            ikeVersion: "2"
+```
+
+## Testing
+
+This collection has been tested against the following environments:
+
+| Cisco Meraki Dashboard API | Ansible "cisco.meraki" | Python "meraki" SDK |
+|----------------------------|------------------------|---------------------|
+| 1.33.0                     | 2.17.0                 | 1.33.0              |
+| 1.44.1                     | 2.18.3                 | 1.44.1              |
+| 1.53.0                     | 2.20.8                 | 1.53.0              |
+| 1.57.0                     | 2.21.2                 | 1.57.0              |
+| 1.68.0                     | 2.23.0                 | 2.2.0               |
 
 *Notes*:
 
-1. The "Python `meraki` SDK version" column has the minimum recommended version used when testing the Ansible collection. This means you could use later versions of the Python "meraki" than those listed.
-2. The "Cisco Meraki version" column has the value of the `meraki_version` you should use for the Ansible collection.
+1. The "Python `meraki` SDK version" column shows the minimum recommended version used during testing. Later versions of the SDK may also be used.
+2. The "Cisco Meraki Dashboard API" column corresponds to the `meraki_version` value you should use with this collection.
+3. This collection is not compatible with versions of Ansible before v2.14.
 
-## Support
+### Known issues
 
-This section should include information about what is supported and how to get support for the collection. This can include supported versions of the collection, how to submit a support request, and any other information about how to get additional assistance. We recommend the following text for certified content only:
-
-As Red Hat Ansible Certified Content, this collection is entitled to support through the Ansible Automation Platform (AAP) using the **Create issue** button on the top right corner. If a support case cannot be opened with Red Hat and the collection has been obtained either from Galaxy or GitHub, there may community help available on the [Ansible Forum](https://forum.ansible.com/).
-
-## Requirements
-- Ansible >= 2.9
-- [Python Meraki SDK](https://github.com/meraki/dashboard-api-python) v1.33.0 or newer
-- Python >= 3.6, as the Meraki SDK doesn't support Python version 2.x
-
-## Attention macOS users
-
-If you're using macOS you may receive this error when running your playbook:
+**macOS users** may encounter the following error when running playbooks:
 
 ```
-objc[34120]: +[__NSCFConstantString initialize] may have been in progress in another thread when fork() was called.
-objc[34120]: +[__NSCFConstantString initialize] may have been in progress in another thread when fork() was called. We cannot safely call it or ignore it in the fork() child process. Crashing instead. Set a breakpoint on objc_initializeAfterForkError to debug.
+objc[34120]: +[__NSCFConstantString initialize] may have been in progress in
+another thread when fork() was called. We cannot safely call it or ignore it
+in the fork() child process. Crashing instead.
 ERROR! A worker was found in a dead state
 ```
 
-If that's the case try setting this environment variable:
+Set the following environment variable to resolve this:
+
 ```
 export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
 ```
 
-## Additional Resources
-1. [Meraki's Ansible Collection Documentation](https://docs.ansible.com/ansible/latest/collections/cisco/meraki/index.html)
-2. [Meraki Dashboard API Documentation](https://meraki.io/api)
-3. [DevNet Learning Lab](https://developer.cisco.com/learning/labs/meraki-dashboard-ansible/introduction/)
-4. [DevNet Sandbox](https://devnetsandbox.cisco.com/RM/Diagram/Index/a9487767-deef-4855-b3e3-880e7f39eadc?diagramType=Topology)
+## Support
+
+As Red Hat Ansible Certified Content, this collection is entitled to support through the Ansible Automation Platform (AAP) using the **Create issue** button on the top right corner. If a support case cannot be opened with Red Hat and the collection has been obtained either from Galaxy or GitHub, there may be community help available on the [Ansible Forum](https://forum.ansible.com/).
+
+## Release Notes and Roadmap
+
+See the full [Changelog](https://github.com/meraki/dashboard-api-ansible/blob/main/CHANGELOG.rst) for release history.
+
+This collection follows [Semantic Versioning](https://semver.org/). More details on versioning can be found [in the Ansible docs](https://docs.ansible.com/ansible/latest/dev_guide/developing_collections.html#collection-versions).
+
+New minor and major releases as well as deprecations will follow new releases and deprecations of the Cisco Meraki product, its REST API and the corresponding Python SDK, which this project relies on.
+
+## Related Information
+
+- [Meraki Ansible Collection Documentation](https://docs.ansible.com/ansible/latest/collections/cisco/meraki/index.html)
+- [Meraki Dashboard API Documentation](https://meraki.io/api)
+- [DevNet Learning Lab](https://developer.cisco.com/learning/labs/meraki-dashboard-ansible/introduction/)
+- [DevNet Sandbox](https://devnetsandbox.cisco.com/RM/Diagram/Index/a9487767-deef-4855-b3e3-880e7f39eadc?diagramType=Topology)
+- [Ansible Galaxy: cisco.meraki](https://galaxy.ansible.com/cisco/meraki)
 
 ## Contributing to this collection
 
 Ongoing development efforts and contributions to this collection are tracked as issues in this repository.
 
-We welcome community contributions to this collection. If you find problems, need an enhancement or need a new module, please open an issue or create a PR against the [Cisco Meraki Ansible collection repository](https://github.com/meraki/dashboard-api-ansible/issues).
+We welcome community contributions to this collection. If you find problems, need an enhancement, or need a new module, please open an issue or create a PR against the [Cisco Meraki Ansible collection repository](https://github.com/meraki/dashboard-api-ansible/issues).
 
-## Code of Conduct
-This collection follows the Ansible project's
-[Code of Conduct](https://docs.ansible.com/ansible/devel/community/code_of_conduct.html).
-Please read and familiarize yourself with this document.
+This collection follows the Ansible project's [Code of Conduct](https://docs.ansible.com/ansible/devel/community/code_of_conduct.html). Please read and familiarize yourself with this document.
 
-## Releasing, Versioning and Deprecation - [Changelog](CHANGELOG.rst)
+## Module migration
 
-This collection follows [Semantic Versioning](https://semver.org/). More details on versioning can be found [in the Ansible docs](https://docs.ansible.com/ansible/latest/dev_guide/developing_collections.html#collection-versions).
-
-New minor and major releases as well as deprecations will follow new releases and deprecations of the Cisco Meraki product, its REST API and the corresponding Python SDK, which this project relies on. 
-
-
-
-## New collection modules
-
-The modules that were there before, usually with a `meraki` prefix, are maintained until version 2.x.x, with the same structure used in previous versions. The old modules will disappear in the next major release and only the new modules will remain. Each old module has its deprecation marking, indicating which is the new equivalent.
+The modules that were there before, usually with a `meraki` prefix, are maintained until version 2.x.x, with the same structure used in previous versions. The old modules will disappear in the next major release and only the new modules will remain. Each old module has its deprecation marking indicating which is the new equivalent.
 
 ### Example
-- Old module:
+
+Old module:
+
+```yaml
+- name: Create webhook
+  cisco.meraki.meraki_webhook:
+    auth_key: abc123
+    state: present
+    org_name: YourOrg
+    net_name: YourNet
+    name: Test_Hookx
+    url: https://webhook.url/
+    shared_secret: shhhdonttellanyone
+    payload_template_name: 'Slack (included)'
+  delegate_to: localhost
 ```
-  - name: Create webhook
-    cisco.meraki.meraki_webhook:
-      auth_key: abc123
-      state: present
-      org_name: YourOrg
-      net_name: YourNet
-      name: Test_Hookx
-      url: https://webhook.url/
-      shared_secret: shhhdonttellanyone
-      payload_template_name: 'Slack (included)'
-    delegate_to: localhost
-```
-- New module:
-```
-  - name: Create webhook
-    cisco.meraki.networks_webhooks_http_servers:
-      meraki_api_key: "{{ meraki_api_key }}"
-      state: present
-      name: Test_Hook
-      networkId: "{{ network_id }}"
-      payloadTemplate:
-        name: Slack (included)
-        payloadTemplateId: wpt_00001
-      sharedSecret: shhhdonttellanyone
-      url: https://webhook.url/
+
+New module:
+
+```yaml
+- name: Create webhook
+  cisco.meraki.networks_webhooks_http_servers:
+    meraki_api_key: "{{ meraki_api_key }}"
+    state: present
+    name: Test_Hook
+    networkId: "{{ network_id }}"
+    payloadTemplate:
+      name: Slack (included)
+      payloadTemplateId: wpt_00001
+    sharedSecret: shhhdonttellanyone
+    url: https://webhook.url/
 ```
 
 ## License

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -1337,3 +1337,9 @@ releases:
         - "networks_wireless_settings: added multicast-to-unicast conversion support."
         - "organizations_inventory_devices_info: added eoxStatuses filtering and included EoX fields in returned inventory device data."
     release_date: "2026-03-18"
+  2.23.1:
+    changes:
+      bugfixes:
+        - "Fixing problem of naming in organizations_appliance_vpn_third_party_vpnpeers_info."
+        - Restructuring README.md file.
+    release_date: "2026-03-23"

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: cisco
 name: meraki
-version: 2.23.0
+version: 2.23.1
 readme: README.md
 authors:
   - Francisco Muñoz <fmunoz@cloverhound.com>

--- a/plugins/plugin_utils/meraki.py
+++ b/plugins/plugin_utils/meraki.py
@@ -264,7 +264,7 @@ class MERAKI(object):
                 suppress_logging=params.get("meraki_suppress_logging"),
                 simulate=params.get("meraki_simulate"),
                 be_geo_id=params.get("meraki_be_geo_id"),
-                caller="MerakiAnsibleCollection/2.23.0 Cisco",
+                caller="MerakiAnsibleCollection/2.23.1 Cisco",
                 use_iterator_for_get_pages=params.get(
                     "meraki_use_iterator_for_get_pages"),
                 inherit_logging_config=params.get(


### PR DESCRIPTION
- Added bugfixes section in CHANGELOG for v2.23.1, including a fix for naming issues in organizations_appliance_vpn_third_party_vpnpeers_info.
- Restructured README.md to improve clarity and organization of installation and usage instructions.