### PR TITLE
Add serial to module invocation arguments in verbose output

### DIFF
--- a/plugins/plugin_utils/meraki.py
+++ b/plugins/plugin_utils/meraki.py
@@ -255,8 +255,11 @@ def meraki_argument_spec():
 
 
 class MERAKI(object):
+    _NO_LOG_PARAMS = frozenset(['meraki_api_key'])
+
     def __init__(self, params):
         self.result = dict(changed=False, result="")
+        self._params = params
         # self.validate_response_schema = params.get("validate_response_schema")
         if MERAKI_SDK_IS_INSTALLED:
             self.api = meraki.DashboardAPI(
@@ -373,6 +376,10 @@ class MERAKI(object):
         raise AnsibleActionFail(msg, kwargs)
 
     def exit_json(self):
+        module_args = {}
+        if self._params.get('serial'):
+            module_args['serial'] = self._params['serial']
+        self.result['invocation'] = {'module_args': module_args}
         return self.result
 
     def verify_array(self, verify_interface, **kwargs):


### PR DESCRIPTION
Problem:
  Meraki action plugins bypass _execute_module() and do all work directly in ActionModule.run().
  This means the invocation dict — which Ansible displays in -vvvv output — was never added to the result. Unlike standard Ansible modules, running a meraki playbook with -vvvv showed no module invocation arguments.
  
  **This is important for indirect node-counting of device modules where serial number is not presnt in module repsonse**

  Fix:
  Two changes in plugins/plugin_utils/meraki.py:
  - Store self._params in MERAKI.__init__()
  - Add invocation.module_args.serial in exit_json() when the serial parameter is present

  Since all 669 action plugins call meraki.exit_json(), this single-file change applies to every
  module in the collection.

  ```
Before (-vvvv output):
  ok: [localhost] =>
    changed: false
    meraki_response: ...
    result: Object already present
```

```
  After (-vvvv output):
  ok: [localhost] =>
    changed: false
    invocation:
      module_args:
        serial:######
    meraki_response: ...
    result: 
```